### PR TITLE
feat(capture): add animation recording and unified PNG capture infras…

### DIFF
--- a/src/e3sm_quickview/app.py
+++ b/src/e3sm_quickview/app.py
@@ -66,6 +66,10 @@ class EAMApp(TrameApp):
                 "timestamps": [],
                 # Fields summaries
                 "fields_avgs": {},
+                # Capture / recording state
+                "capture_variable": None,
+                "capture_recording": False,
+                "capture_action": None,
             }
         )
 
@@ -200,6 +204,15 @@ class EAMApp(TrameApp):
 
             # Native Dialogs
             client.ClientTriggers(mounted="is_tauri = !!window.__TAURI__")
+
+            # JS helpers for server-to-client capture calls
+            # Store on server so Animation component can access them
+            self.server._js_capture_frame = client.JSEval(
+                exec="window.captureCollectFrame(capture_action.variable, capture_action.index)",
+            )
+            self.server._js_capture_download = client.JSEval(
+                exec="window.captureDownloadZip(capture_action.variable)",
+            )
             with tauri.Dialog() as dialog:
                 self.ctrl.save = dialog.save
 

--- a/src/e3sm_quickview/components/toolbars.py
+++ b/src/e3sm_quickview/components/toolbars.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from trame.app import asynchronous
-from trame.decorators import change
+from trame.decorators import change, trigger
 from trame.widgets import client, html
 from trame.widgets import vuetify3 as v3
 
@@ -486,6 +486,30 @@ class Animation(v3.VToolbar):
                     icon=("animation_play ? 'mdi-stop' : 'mdi-play'",),
                     flat=True,
                     click="animation_play = !animation_play",
+                    disabled=("capture_recording",),
+                )
+                v3.VDivider(vertical=True, classes="mx-2")
+                v3.VSelect(
+                    v_model=("capture_variable", None),
+                    items=("variables_selected", []),
+                    flat=True,
+                    variant="plain",
+                    hide_details=True,
+                    density="compact",
+                    placeholder="Panel",
+                    style="max-width: 10rem;",
+                )
+                v3.VIconBtn(
+                    v_tooltip_bottom="'Record animation as PNG sequence (ZIP)'",
+                    icon=(
+                        "capture_recording ? 'mdi-stop-circle' : 'mdi-record-circle'",
+                    ),
+                    color=("capture_recording ? 'red' : ''",),
+                    flat=True,
+                    disabled=(
+                        "!capture_variable || !animation_track || animation_play",
+                    ),
+                    click="_ensureCaptureStream().then(() => trigger('capture_animation', [capture_variable]))",
                 )
 
     @change("animation_track")
@@ -508,13 +532,56 @@ class Animation(v3.VToolbar):
         if animation_play:
             asynchronous.create_task(self._run_animation())
 
+    async def _step_to(self, step):
+        """Advance animation to a given step and wait for render."""
+        with self.state:
+            self.state.animation_step = step
+        await self.server.network_completion
+
     async def _run_animation(self):
         with self.state as s:
             while s.animation_play:
                 await asyncio.sleep(0.1)
                 if s.animation_step < s.animation_step_max:
-                    with s:
-                        s.animation_step += 1
-                    await self.server.network_completion
+                    await self._step_to(s.animation_step + 1)
                 else:
                     s.animation_play = False
+
+    @trigger("capture_animation")
+    def capture_animation(self, variable_name):
+        """Record every frame of the current animation track for a variable."""
+        asynchronous.create_task(self._run_capture(variable_name))
+
+    async def _run_capture(self, variable_name):
+        """Record every frame of the current animation track."""
+        track = self.state.animation_track
+        if not track:
+            return
+
+        values = self.state[track]
+        if not values:
+            return
+
+        n_frames = len(values)
+
+        with self.state:
+            self.state.capture_recording = True
+
+        await asyncio.sleep(0.3)
+
+        for i in range(n_frames):
+            await self._step_to(i)
+            await asyncio.sleep(0.2)
+
+            with self.state:
+                self.state.capture_action = {"variable": variable_name, "index": i}
+            self.server._js_capture_frame.exec()
+            await self.server.network_completion
+            await asyncio.sleep(0.1)
+
+        with self.state:
+            self.state.capture_action = {"variable": variable_name}
+        self.server._js_capture_download.exec()
+
+        with self.state:
+            self.state.capture_recording = False

--- a/src/e3sm_quickview/module/serve/utils.js
+++ b/src/e3sm_quickview/module/serve/utils.js
@@ -105,7 +105,363 @@ class QueryFilter {
 
 QUERY_FILTER = new QueryFilter();
 
+// ---------------------------------------------------------------------------
+// Panel capture helpers
+// ---------------------------------------------------------------------------
+
+function _findPanelCard(variableName) {
+  // Look for the VCard by its datapanel attribute (set in Python).
+  const card = document.querySelector(`.v-card[datapanel="${variableName}"]`);
+  if (card) return card;
+
+  // Fallback: match by title text
+  const cards = document.querySelectorAll(".v-card");
+  for (const c of cards) {
+    const sub = c.querySelector(".text-subtitle-2");
+    if (sub && sub.textContent.trim() === variableName) {
+      return c;
+    }
+  }
+  return null;
+}
+
+function _downloadDataURL(dataURL, filename) {
+  const a = document.createElement("a");
+  a.href = dataURL;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+// Shared screen-capture stream.
+// Opened once (on user gesture), reused across frames, closed after use.
+window.__captureStream = null;
+window.__captureVideo = null;
+window.__captureFrames = [];
+
+async function _ensureCaptureStream() {
+  if (window.__captureStream && window.__captureVideo) {
+    return window.__captureVideo;
+  }
+  _hideCaptureArtifacts();
+  const stream = await navigator.mediaDevices.getDisplayMedia({
+    video: { displaySurface: "browser", cursor: "never" },
+    preferCurrentTab: true,
+  });
+  window.__captureStream = stream;
+  const video = document.createElement("video");
+  video.srcObject = stream;
+  video.autoplay = true;
+  await new Promise((resolve) => {
+    video.onloadedmetadata = () => {
+      video.play();
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    };
+  });
+  window.__captureVideo = video;
+  return video;
+}
+
+function _stopCaptureStream() {
+  if (window.__captureStream) {
+    for (const track of window.__captureStream.getTracks()) track.stop();
+  }
+  window.__captureStream = null;
+  window.__captureVideo = null;
+  _restoreCaptureArtifacts();
+}
+
+function _hideCaptureArtifacts() {
+  // Hide cursor so it doesn't appear in screen capture
+  document.documentElement.style.cursor = "none";
+  document.body.style.cursor = "none";
+  // Hide tooltips
+  document
+    .querySelectorAll(".v-tooltip .v-overlay__content")
+    .forEach((el) => (el.style.display = "none"));
+  if (document.activeElement) document.activeElement.blur();
+}
+
+function _restoreCaptureArtifacts() {
+  document.documentElement.style.cursor = "";
+  document.body.style.cursor = "";
+  document
+    .querySelectorAll(".v-tooltip .v-overlay__content")
+    .forEach((el) => (el.style.display = ""));
+}
+
+function _cropCardFromVideo(card, video) {
+  const vw = video.videoWidth;
+  const vh = video.videoHeight;
+  const scaleX = vw / window.innerWidth;
+  const scaleY = vh / window.innerHeight;
+  const rect = card.getBoundingClientRect();
+  const sx = Math.round(rect.left * scaleX);
+  const sy = Math.round(rect.top * scaleY);
+  const sw = Math.round(rect.width * scaleX);
+  const sh = Math.round(rect.height * scaleY);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = sw;
+  canvas.height = sh;
+  canvas.getContext("2d").drawImage(video, sx, sy, sw, sh, 0, 0, sw, sh);
+  return canvas;
+}
+
+async function capturePanel(variableName, timeIdx, midpointIdx, interfaceIdx) {
+  const card = _findPanelCard(variableName);
+  if (!card) {
+    console.warn(`[capture] Panel for "${variableName}" not found`);
+    return;
+  }
+
+  _hideCaptureArtifacts();
+  await new Promise((r) => setTimeout(r, 300));
+
+  try {
+    const video = await _ensureCaptureStream();
+    const canvas = _cropCardFromVideo(card, video);
+    const dataURL = canvas.toDataURL("image/png");
+
+    let filename = variableName;
+    if (timeIdx != null) filename += `_t${timeIdx}`;
+    if (midpointIdx != null) filename += `_k${midpointIdx}`;
+    if (interfaceIdx != null) filename += `_k${interfaceIdx}`;
+    _downloadDataURL(dataURL, `${filename}.png`);
+  } catch (err) {
+    console.error("[capture] Screen capture failed:", err);
+  } finally {
+    _restoreCaptureArtifacts();
+    _stopCaptureStream();
+  }
+}
+
+function captureCollectFrame(variableName, frameIndex) {
+  const card = _findPanelCard(variableName);
+  const video = window.__captureVideo;
+  if (!card || !video) {
+    console.warn(
+      `[capture] frame ${frameIndex}: card=${!!card} video=${!!video}`,
+    );
+    return;
+  }
+
+  const canvas = _cropCardFromVideo(card, video);
+  const dataURL = canvas.toDataURL("image/png");
+  // Decode data URL to Uint8Array eagerly so download can be synchronous
+  const binary = atob(dataURL.split(",")[1]);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  const pad = String(frameIndex).padStart(5, "0");
+  window.__captureFrames.push({
+    name: `${variableName}_${pad}.png`,
+    data: bytes,
+  });
+  console.log(`[capture] collected frame ${frameIndex}, ${bytes.length} bytes`);
+}
+
+// CRC-32 lookup table
+const _crc32Table = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+
+function _crc32(data) {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc = _crc32Table[(crc ^ data[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function _dosDateTime() {
+  const d = new Date();
+  const time =
+    (d.getHours() << 11) | (d.getMinutes() << 5) | (d.getSeconds() >> 1);
+  const date =
+    ((d.getFullYear() - 1980) << 9) | ((d.getMonth() + 1) << 5) | d.getDate();
+  return { time, date };
+}
+
+function _buildZipBlob(entries) {
+  // entries: [{name: string, data: Uint8Array}, ...]
+  const parts = [];
+  const centralDir = [];
+  let offset = 0;
+  const { time: dosTime, date: dosDate } = _dosDateTime();
+
+  for (const file of entries) {
+    const nameBytes = new TextEncoder().encode(file.name);
+    const data = file.data;
+    const crc = _crc32(data);
+
+    const localHeader = new Uint8Array(30 + nameBytes.length);
+    const lv = new DataView(localHeader.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint16(6, 0, true);
+    lv.setUint16(8, 0, true);
+    lv.setUint16(10, dosTime, true);
+    lv.setUint16(12, dosDate, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, data.length, true);
+    lv.setUint32(22, data.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    lv.setUint16(28, 0, true);
+    localHeader.set(nameBytes, 30);
+
+    const cdEntry = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(cdEntry.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint16(8, 0, true);
+    cv.setUint16(10, dosTime, true);
+    cv.setUint16(12, dosDate, true);
+    cv.setUint16(14, 0, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, data.length, true);
+    cv.setUint32(24, data.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint16(30, 0, true);
+    cv.setUint16(32, 0, true);
+    cv.setUint16(34, 0, true);
+    cv.setUint16(36, 0, true);
+    cv.setUint32(38, 0, true);
+    cv.setUint32(42, offset, true);
+    cdEntry.set(nameBytes, 46);
+
+    parts.push(localHeader, data);
+    centralDir.push(cdEntry);
+    offset += localHeader.length + data.length;
+  }
+
+  let cdSize = 0;
+  for (const e of centralDir) cdSize += e.length;
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(4, 0, true);
+  ev.setUint16(6, 0, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, cdSize, true);
+  ev.setUint32(16, offset, true);
+  ev.setUint16(20, 0, true);
+
+  return new Blob([...parts, ...centralDir, eocd], { type: "application/zip" });
+}
+
+function _renderVideoFromFrames(frames, fps) {
+  return new Promise((resolve, reject) => {
+    if (!frames.length) return reject("No frames");
+
+    const firstImg = new Image();
+    const firstBlob = new Blob([frames[0].data], { type: "image/png" });
+    firstImg.onload = () => {
+      const w = firstImg.naturalWidth;
+      const h = firstImg.naturalHeight;
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext("2d");
+
+      const stream = canvas.captureStream(0);
+      const mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9")
+        ? "video/webm;codecs=vp9"
+        : "video/webm";
+      const recorder = new MediaRecorder(stream, {
+        mimeType,
+        videoBitsPerSecond: 8_000_000,
+      });
+      const chunks = [];
+      recorder.ondataavailable = (e) => {
+        if (e.data.size) chunks.push(e.data);
+      };
+      recorder.onstop = () => {
+        const videoBlob = new Blob(chunks, { type: mimeType });
+        videoBlob.arrayBuffer().then((ab) => {
+          resolve({ data: new Uint8Array(ab), ext: "webm" });
+        });
+      };
+      recorder.onerror = reject;
+      recorder.start();
+
+      let idx = 0;
+      const drawNext = () => {
+        if (idx >= frames.length) {
+          recorder.stop();
+          return;
+        }
+        const img = new Image();
+        const blob = new Blob([frames[idx].data], { type: "image/png" });
+        img.onload = () => {
+          ctx.clearRect(0, 0, w, h);
+          ctx.drawImage(img, 0, 0, w, h);
+          URL.revokeObjectURL(img.src);
+          const track = stream.getVideoTracks()[0];
+          if (track.requestFrame) track.requestFrame();
+          idx++;
+          setTimeout(drawNext, 1000 / fps);
+        };
+        img.src = URL.createObjectURL(blob);
+      };
+      drawNext();
+    };
+    firstImg.src = URL.createObjectURL(firstBlob);
+  });
+}
+
+function captureDownloadZip(variableName) {
+  const frames = window.__captureFrames;
+  if (!frames.length) {
+    console.warn("[capture] No frames collected");
+    return;
+  }
+  console.log(`[capture] building ZIP with ${frames.length} frames + video`);
+
+  const fps = 5;
+  _renderVideoFromFrames(frames, fps)
+    .then((video) => {
+      // Add video to the entries alongside the PNGs
+      const entries = frames.map((f) => ({ name: f.name, data: f.data }));
+      entries.push({
+        name: `${variableName}_animation.${video.ext}`,
+        data: video.data,
+      });
+      const zipBlob = _buildZipBlob(entries);
+      const url = URL.createObjectURL(zipBlob);
+      _downloadDataURL(url, `${variableName}_animation.zip`);
+      setTimeout(() => URL.revokeObjectURL(url), 3000);
+      window.__captureFrames = [];
+      _stopCaptureStream();
+    })
+    .catch((err) => {
+      console.warn("[capture] Video encoding failed, saving PNGs only:", err);
+      const entries = frames.map((f) => ({ name: f.name, data: f.data }));
+      const zipBlob = _buildZipBlob(entries);
+      const url = URL.createObjectURL(zipBlob);
+      _downloadDataURL(url, `${variableName}_animation.zip`);
+      setTimeout(() => URL.revokeObjectURL(url), 3000);
+      window.__captureFrames = [];
+      _stopCaptureStream();
+    });
+}
+
+// Expose capture functions on window for JSEval access
+window.captureCollectFrame = captureCollectFrame;
+window.captureDownloadZip = captureDownloadZip;
+
 window.trame.utils.quickview = {
+  capturePanel,
   formatRange(value, useLog, rangeMin, rangeMax) {
     if (value === null || value === undefined || isNaN(value)) {
       return "Auto";

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -363,6 +363,7 @@ class VariableView(TrameComponent):
                     "active_layout !== 'auto_layout' ? `height: calc(100% - ${top_padding}px;` : 'overflow-hidden'",
                 ),
                 tile=("active_layout !== 'auto_layout'",),
+                datapanel=self.variable_name,
             ):
                 with v3.VRow(
                     dense=True,
@@ -419,6 +420,13 @@ class VariableView(TrameComponent):
                         f"fields_avgs['{self.variable_name}']?.toExponential(2) || 'N/A'"
                         "}}",
                         classes="text-caption px-1 text-no-wrap",
+                    )
+                    v3.VIconBtn(
+                        v_tooltip_bottom="'Capture panel as PNG'",
+                        icon="mdi-camera",
+                        size="x-small",
+                        variant="plain",
+                        click=f"utils.quickview.capturePanel('{self.variable_name}', time_idx, midpoint_idx, interface_idx)",
                     )
 
                 with html.Div(

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -380,6 +380,7 @@ class VariableView(TrameComponent):
                     "active_layout !== 'auto_layout' ? `height: calc(100% - ${top_padding}px;` : 'overflow-hidden'",
                 ),
                 tile=("active_layout !== 'auto_layout'",),
+                datapanel=self.variable_name,
             ):
                 with v3.VRow(
                     dense=True,
@@ -436,6 +437,13 @@ class VariableView(TrameComponent):
                         f"fields_avgs['{self.variable_name}']?.toExponential(2) || 'N/A'"
                         "}}",
                         classes="text-caption px-1 text-no-wrap",
+                    )
+                    v3.VIconBtn(
+                        v_tooltip_bottom="'Capture panel as PNG'",
+                        icon="mdi-camera",
+                        size="x-small",
+                        variant="plain",
+                        click=f"utils.quickview.capturePanel('{self.variable_name}', time_idx, midpoint_idx, interface_idx)",
                     )
 
                 with html.Div(


### PR DESCRIPTION
Adds animation recording and single-panel PNG capture with shared infrastructure:
- Screen capture stream, cropping, and cursor/tooltip hiding shared across both paths
- Animation playback and recording share stepping logic via _step_to()
- Animation capture trigger added to Animation component in toolbars.py
- WebM video encoding via MediaRecorder included in ZIP with PNG frames

closes #23 