### PR TITLE
Performance analysis

### DIFF
--- a/src/e3sm_quickview/app.py
+++ b/src/e3sm_quickview/app.py
@@ -18,7 +18,7 @@ from e3sm_quickview import module as qv_module
 from e3sm_quickview.assets import ASSETS
 from e3sm_quickview.components import css, dialogs, doc, drawers, file_browser, toolbars
 from e3sm_quickview.pipeline import EAMVisSource
-from e3sm_quickview.utils import cli, compute
+from e3sm_quickview.utils import cli, compute, perf
 
 v3.enable_lab()
 
@@ -44,6 +44,10 @@ class EAMApp(TrameApp):
 
         # CLI
         args = cli.configure_and_parse(self.server.cli)
+
+        # Enable performance instrumentation if requested. This is a global
+        # toggle read by the utils.perf module in every instrumented scope.
+        perf.enable(args.perf)
 
         # Initial UI state
         self.state.update(
@@ -495,41 +499,47 @@ class EAMApp(TrameApp):
         # Give some room
         await asyncio.sleep(0.1)
 
-        vars_to_show = self.selected_variables
+        with perf.timed("load_variables.total"):
+            vars_to_show = self.selected_variables
 
-        # Flatten the list of lists
-        flattened_vars = [var for var_list in vars_to_show.values() for var in var_list]
+            # Flatten the list of lists
+            flattened_vars = [var for var_list in vars_to_show.values() for var in var_list]
 
-        # Compute used dimensions
-        used_dims = set()
-        for dims in self.selected_variables.keys():
-            used_dims.update(dims)
-        self.state.available_animation_tracks = [
-            n for n in self.state.animation_tracks if n in used_dims
-        ]
-        self.state.animation_track = (
-            self.state.available_animation_tracks[0]
-            if self.state.available_animation_tracks
-            else None
-        )
+            # Compute used dimensions
+            used_dims = set()
+            for dims in self.selected_variables.keys():
+                used_dims.update(dims)
+            self.state.available_animation_tracks = [
+                n for n in self.state.animation_tracks if n in used_dims
+            ]
+            self.state.animation_track = (
+                self.state.available_animation_tracks[0]
+                if self.state.available_animation_tracks
+                else None
+            )
 
-        self.source.LoadVariables(flattened_vars)
+            with perf.timed("load_variables.LoadVariables"):
+                self.source.LoadVariables(flattened_vars)
 
-        # Trigger source update + compute avg
-        with self.state:
-            self.state.variables_loaded = True
+            # Trigger source update + compute avg
+            with self.state:
+                self.state.variables_loaded = True
 
-        await self.server.network_completion
+            with perf.timed("load_variables.network_completion_1"):
+                await self.server.network_completion
 
-        # Update views in layout
-        with self.state:
-            self.view_manager.build_auto_layout(vars_to_show)
+            # Update views in layout
+            with perf.timed("load_variables.build_auto_layout"):
+                with self.state:
+                    self.view_manager.build_auto_layout(vars_to_show)
 
-        await self.server.network_completion
+            with perf.timed("load_variables.network_completion_2"):
+                await self.server.network_completion
 
-        # Reset camera after yield
-        await asyncio.sleep(0.1)
-        self.view_manager.reset_camera()
+            # Reset camera after yield
+            await asyncio.sleep(0.1)
+            with perf.timed("load_variables.reset_camera"):
+                self.view_manager.reset_camera()
 
         # Done with the loading
         t1 = time.perf_counter()
@@ -580,20 +590,25 @@ class EAMApp(TrameApp):
         self.state.top_padding = top_padding
 
     def _on_slicing_change(self, var, ind_var, **_):
-        self.source.UpdateSlicing(var, self.state[ind_var])
-        self.source.UpdatePipeline()
+        with perf.timed(f"tick.{var}={self.state[ind_var]}.total"):
+            with perf.timed("tick.pipeline"):
+                self.source.UpdateSlicing(var, self.state[ind_var])
+                self.source.UpdatePipeline()
 
-        self.view_manager.update_color_range()
-        self.view_manager.render()
+            with perf.timed("tick.color_range"):
+                self.view_manager.update_color_range()
+            with perf.timed("tick.render"):
+                self.view_manager.render()
 
-        # Update avg computation
-        # Get area variable to calculate weighted average
-        geom_filter = self.source.views["atmosphere_data"]
-        geom_filter.Update()
-        data = geom_filter.GetOutput()
-        self.state.fields_avgs = compute.extract_avgs(
-            data, self.selected_variable_names
-        )
+            with perf.timed("tick.extract_avgs"):
+                # Update avg computation
+                # Get area variable to calculate weighted average
+                geom_filter = self.source.views["atmosphere_data"]
+                geom_filter.Update()
+                data = geom_filter.GetOutput()
+                self.state.fields_avgs = compute.extract_avgs(
+                    data, self.selected_variable_names
+                )
 
     @change(
         "variables_loaded",
@@ -612,21 +627,26 @@ class EAMApp(TrameApp):
         if not variables_loaded:
             return
 
-        self.source.ApplyClipping(crop_longitude, crop_latitude)
-        self.source.UpdateProjection(projection[0])
-        self.source.UpdatePipeline()
+        with perf.timed("downstream_change.total"):
+            with perf.timed("downstream_change.pipeline"):
+                self.source.ApplyClipping(crop_longitude, crop_latitude)
+                self.source.UpdateProjection(projection[0])
+                self.source.UpdatePipeline()
 
-        self.view_manager.update_color_range()
-        self.view_manager.render()
+            with perf.timed("downstream_change.color_range"):
+                self.view_manager.update_color_range()
+            with perf.timed("downstream_change.render"):
+                self.view_manager.render()
 
-        # Update avg computation
-        # Get area variable to calculate weighted average
-        geom_filter = self.source.views["atmosphere_data"]
-        geom_filter.Update()
-        data = geom_filter.GetOutput()
-        self.state.fields_avgs = compute.extract_avgs(
-            data, self.selected_variable_names
-        )
+            with perf.timed("downstream_change.extract_avgs"):
+                # Update avg computation
+                # Get area variable to calculate weighted average
+                geom_filter = self.source.views["atmosphere_data"]
+                geom_filter.Update()
+                data = geom_filter.GetOutput()
+                self.state.fields_avgs = compute.extract_avgs(
+                    data, self.selected_variable_names
+                )
 
     def toggle_toolbar(self, toolbar_name=None):
         if toolbar_name is None:

--- a/src/e3sm_quickview/plugins/eam_projection.py
+++ b/src/e3sm_quickview/plugins/eam_projection.py
@@ -90,6 +90,23 @@ except ImportError as ie:
     )
     _has_deps = False
 
+try:
+    from e3sm_quickview.utils import perf as _perf
+except ImportError:
+    # Plugin may be loaded by paraview with quickview not on sys.path; fall
+    # back to a no-op shim so the filter still works.
+    from contextlib import contextmanager
+
+    class _perf:  # type: ignore[no-redef]
+        @staticmethod
+        def is_enabled():
+            return False
+
+        @staticmethod
+        @contextmanager
+        def timed(label):
+            yield
+
 
 def ProcessPoint(point, radius):
     # theta = math.radians(point[0] - 180.)
@@ -157,7 +174,8 @@ def add_cell_arrays(inData, outData, cached_output):
         return
 
     pedigree_vtk = cached_output.GetCellData().GetArray("PedigreeIds")
-    starts, ends, pid_np = _get_pedigree_slice_plan(pedigree_vtk)
+    with _perf.timed("add_cell_arrays.slice_plan"):
+        starts, ends, pid_np = _get_pedigree_slice_plan(pedigree_vtk)
 
     cached_cell_data = cached_output.GetCellData()
     in_cell_data = inData.GetCellData()
@@ -172,21 +190,22 @@ def add_cell_arrays(inData, outData, cached_output):
             # This scalar has been seen before — reuse cached copy.
             out_cell_data.AddArray(cached_array)
         else:
-            array0 = cached_cell_data.GetArray(0)
-            n_comp = array0.GetNumberOfComponents()
-            n_tuples = array0.GetNumberOfTuples()
-            out_array = in_array.NewInstance()
-            out_array.SetNumberOfComponents(n_comp)
-            out_array.SetNumberOfTuples(n_tuples)
-            out_array.SetName(in_array.GetName())
-            out_cell_data.AddArray(out_array)
+            with _perf.timed(f"add_cell_arrays.pedigree_copy.{in_array.GetName()}"):
+                array0 = cached_cell_data.GetArray(0)
+                n_comp = array0.GetNumberOfComponents()
+                n_tuples = array0.GetNumberOfTuples()
+                out_array = in_array.NewInstance()
+                out_array.SetNumberOfComponents(n_comp)
+                out_array.SetNumberOfTuples(n_tuples)
+                out_array.SetName(in_array.GetName())
+                out_cell_data.AddArray(out_array)
 
-            in_np = numpy_support.vtk_to_numpy(in_array)
-            out_np = numpy_support.vtk_to_numpy(out_array)
-            for s, e in zip(starts, ends):
-                src_off = int(pid_np[s])
-                out_np[s:e] = in_np[src_off:src_off + (e - s)]
-            out_array.Modified()
+                in_np = numpy_support.vtk_to_numpy(in_array)
+                out_np = numpy_support.vtk_to_numpy(out_array)
+                for s, e in zip(starts, ends):
+                    src_off = int(pid_np[s])
+                    out_np[s:e] = in_np[src_off:src_off + (e - s)]
+                out_array.Modified()
 
 
 @smproxy.filter()
@@ -398,61 +417,66 @@ class EAMProject(VTKPythonAlgorithmBase):
             self.Modified()
 
     def RequestData(self, request, inInfo, outInfo):
-        inData = self.GetInputData(inInfo, 0, 0)
-        outData = self.GetOutputData(outInfo, 0)
-        if inData.IsA("vtkPolyData"):
-            afilter = vtkAppendFilter()
-            afilter.AddInputData(inData)
-            afilter.Update()
-            outData.ShallowCopy(afilter.GetOutput())
-        else:
-            outData.ShallowCopy(inData)
+        with _perf.timed("project.RequestData"):
+            inData = self.GetInputData(inInfo, 0, 0)
+            outData = self.GetOutputData(outInfo, 0)
+            if inData.IsA("vtkPolyData"):
+                afilter = vtkAppendFilter()
+                afilter.AddInputData(inData)
+                afilter.Update()
+                outData.ShallowCopy(afilter.GetOutput())
+            else:
+                outData.ShallowCopy(inData)
 
-        in_points = inData.GetPoints()
-        cache_key = (id(in_points), self.project, self.translate)
-        if self.cached_points is not None and self._cached_key == cache_key:
-            outData.SetPoints(self.cached_points)
-        else:
-            # we modify the points, so copy them
-            out_points_vtk = vtkPoints()
-            out_points_vtk.DeepCopy(outData.GetPoints())
-            outData.SetPoints(out_points_vtk)
-            out_points_np = outData.points
+            in_points = inData.GetPoints()
+            cache_key = (id(in_points), self.project, self.translate)
+            if self.cached_points is not None and self._cached_key == cache_key:
+                with _perf.timed("project.cache_hit"):
+                    outData.SetPoints(self.cached_points)
+            else:
+                with _perf.timed("project.cache_miss"):
+                    # we modify the points, so copy them
+                    with _perf.timed("project.deep_copy_points"):
+                        out_points_vtk = vtkPoints()
+                        out_points_vtk.DeepCopy(outData.GetPoints())
+                        outData.SetPoints(out_points_vtk)
+                    out_points_np = outData.points
 
-            flat = out_points_np.flatten()
-            x = flat[0::3] - 180.0 if self.translate else flat[0::3]
-            y = flat[1::3]
+                    flat = out_points_np.flatten()
+                    x = flat[0::3] - 180.0 if self.translate else flat[0::3]
+                    y = flat[1::3]
 
-            try:
-                # Use proj4 string for WGS84 instead of EPSG code to avoid database dependency
-                latlon = Proj(proj="latlong", datum="WGS84")
-                if self.project == 1:
-                    proj = Proj(proj="robin")
-                elif self.project == 2:
-                    proj = Proj(proj="moll")
-                else:
-                    # Should not reach here, but return without transformation
-                    return 1
+                    try:
+                        # Use proj4 string for WGS84 instead of EPSG code to avoid database dependency
+                        latlon = Proj(proj="latlong", datum="WGS84")
+                        if self.project == 1:
+                            proj = Proj(proj="robin")
+                        elif self.project == 2:
+                            proj = Proj(proj="moll")
+                        else:
+                            # Should not reach here, but return without transformation
+                            return 1
 
-                xformer = Transformer.from_proj(latlon, proj, always_xy=True)
-                res = _threaded_transform(xformer, x, y)
-            except Exception as e:
-                print(f"Projection error: {e}")
-                # If projection fails, return without modifying coordinates
-                return 1
-            flat[0::3] = np.array(res[0])
-            flat[1::3] = np.array(res[1])
+                        xformer = Transformer.from_proj(latlon, proj, always_xy=True)
+                        with _perf.timed("project.pyproj_transform"):
+                            res = _threaded_transform(xformer, x, y)
+                    except Exception as e:
+                        print(f"Projection error: {e}")
+                        # If projection fails, return without modifying coordinates
+                        return 1
+                    flat[0::3] = np.array(res[0])
+                    flat[1::3] = np.array(res[1])
 
-            outPoints = flat.reshape(out_points_np.shape)
-            _coords = numpy_support.numpy_to_vtk(outPoints, deep=True)
-            outData.GetPoints().SetData(_coords)
-            # the previous cached_points, if any, is available for
-            # garbage collection after this assignment
-            self.cached_points = out_points_vtk
-            self._cached_input_points = in_points  # hold ref so id() stays valid
-            self._cached_key = cache_key
+                    outPoints = flat.reshape(out_points_np.shape)
+                    _coords = numpy_support.numpy_to_vtk(outPoints, deep=True)
+                    outData.GetPoints().SetData(_coords)
+                    # the previous cached_points, if any, is available for
+                    # garbage collection after this assignment
+                    self.cached_points = out_points_vtk
+                    self._cached_input_points = in_points  # hold ref so id() stays valid
+                    self._cached_key = cache_key
 
-        return 1
+            return 1
 
 
 @smproxy.filter()
@@ -595,90 +619,96 @@ class EAMExtract(VTKPythonAlgorithmBase):
             self.Modified()
 
     def RequestData(self, request, inInfo, outInfo):
-        inData = self.GetInputData(inInfo, 0, 0)
-        outData = self.GetOutputData(outInfo, 0)
-        if self.trim_lon == [0, 0] and self.trim_lat == [0, 0]:
-            outData.ShallowCopy(inData)
-            # Only invalidate the shared points when transitioning *out* of a
-            # trimmed state — the original code did it unconditionally, which
-            # defeated EAMProject's cache on every pipeline update.
-            if self._last_was_trimmed:
-                outData.GetPoints().Modified()
-                self._last_was_trimmed = False
+        with _perf.timed("extract.RequestData"):
+            inData = self.GetInputData(inInfo, 0, 0)
+            outData = self.GetOutputData(outInfo, 0)
+            if self.trim_lon == [0, 0] and self.trim_lat == [0, 0]:
+                outData.ShallowCopy(inData)
+                # Only invalidate the shared points when transitioning *out* of a
+                # trimmed state — the original code did it unconditionally, which
+                # defeated EAMProject's cache on every pipeline update.
+                if self._last_was_trimmed:
+                    outData.GetPoints().Modified()
+                    self._last_was_trimmed = False
+                return 1
+
+            if self.cached_cell_centers and self.cached_cell_centers.GetMTime() >= max(
+                inData.GetPoints().GetMTime(), inData.GetCells().GetMTime()
+            ):
+                cell_centers = self.cached_cell_centers
+            else:
+                with _perf.timed("extract.cell_centers"):
+                    # convert to polydata, as vtkCellCenters only works on polydata
+                    to_poly = vtkGeometryFilter()
+                    to_poly.SetInputData(inData)
+
+                    # get cell centers
+                    compute_centers = vtkCellCenters()
+                    compute_centers.SetInputConnection(to_poly.GetOutputPort())
+                    compute_centers.Update()
+                    cell_centers = compute_centers.GetOutput().GetPoints().GetData()
+                    # previous cached_cell_centers, if any,
+                    # is available for garbage collection after this assignment
+                    self.cached_cell_centers = cell_centers
+
+            # get the numpy array for cell centers
+            cc = numpy_support.vtk_to_numpy(cell_centers)
+
+            if self._cached_output and self._cached_output.GetMTime() >= max(
+                self.GetMTime(), inData.GetPoints().GetMTime(), cell_centers.GetMTime()
+            ):
+                with _perf.timed("extract.cache_hit"):
+                    outData.ShallowCopy(self._cached_output)
+                    add_cell_arrays(inData, outData, self._cached_output)
+            else:
+                with _perf.timed("extract.rebuild_trim"):
+                    # add PedigreeIds
+                    generate_ids = vtkGenerateIds()
+                    generate_ids.SetInputData(inData)
+                    generate_ids.PointIdsOff()
+                    generate_ids.SetCellIdsArrayName("PedigreeIds")
+                    generate_ids.Update()
+                    outData.ShallowCopy(generate_ids.GetOutput())
+                    # we have to deep copy the cell array because we modify it
+                    # with RemoveGhostCells
+                    with _perf.timed("extract.deep_copy_cells"):
+                        cells = vtkCellArray()
+                        cell_types = vtkUnsignedCharArray()
+                        cells.DeepCopy(outData.GetCells())
+                        cell_types.DeepCopy(outData.GetCellTypesArray())
+                        outData.SetCells(cell_types, cells)
+
+                    # compute the new bounds by trimming the inData bounds
+                    bounds = list(inData.GetBounds())
+                    bounds[0] = bounds[0] + self.trim_lon[0]
+                    bounds[1] = bounds[1] - self.trim_lon[1]
+                    bounds[2] = bounds[2] + self.trim_lat[0]
+                    bounds[3] = bounds[3] - self.trim_lat[1]
+
+                    # add HIDDENCELL based on bounds
+                    with _perf.timed("extract.ghost_mask"):
+                        outside_mask = (
+                            (cc[:, 0] < bounds[0])
+                            | (cc[:, 0] > bounds[1])
+                            | (cc[:, 1] < bounds[2])
+                            | (cc[:, 1] > bounds[3])
+                        )
+                        # Create ghost array (0 = visible, HIDDENCELL = invisible)
+                        ghost_np = np.where(
+                            outside_mask, vtkDataSetAttributes.HIDDENCELL, 0
+                        ).astype(np.uint8)
+
+                        # Convert to VTK and add to output
+                        ghost = numpy_support.numpy_to_vtk(ghost_np)
+                        ghost.SetName(vtkDataSetAttributes.GhostArrayName())
+                        outData.GetCellData().AddArray(ghost)
+                    with _perf.timed("extract.remove_ghost_cells"):
+                        outData.RemoveGhostCells()
+
+                    self._cached_output = outData.NewInstance()
+                    self._cached_output.ShallowCopy(outData)
+            self._last_was_trimmed = True
             return 1
-
-        if self.cached_cell_centers and self.cached_cell_centers.GetMTime() >= max(
-            inData.GetPoints().GetMTime(), inData.GetCells().GetMTime()
-        ):
-            cell_centers = self.cached_cell_centers
-        else:
-            # convert to polydata, as vtkCellCenters only works on polydata
-            # import pdb;pdb.set_trace()
-            to_poly = vtkGeometryFilter()
-            to_poly.SetInputData(inData)
-
-            # get cell centers
-            compute_centers = vtkCellCenters()
-            compute_centers.SetInputConnection(to_poly.GetOutputPort())
-            compute_centers.Update()
-            cell_centers = compute_centers.GetOutput().GetPoints().GetData()
-            # previous cached_cell_centers, if any,
-            # is available for garbage collection after this assignment
-            self.cached_cell_centers = cell_centers
-
-        # get the numpy array for cell centers
-        cc = numpy_support.vtk_to_numpy(cell_centers)
-
-        if self._cached_output and self._cached_output.GetMTime() >= max(
-            self.GetMTime(), inData.GetPoints().GetMTime(), cell_centers.GetMTime()
-        ):
-            outData.ShallowCopy(self._cached_output)
-            add_cell_arrays(inData, outData, self._cached_output)
-        else:
-            # add PedigreeIds
-            generate_ids = vtkGenerateIds()
-            generate_ids.SetInputData(inData)
-            generate_ids.PointIdsOff()
-            generate_ids.SetCellIdsArrayName("PedigreeIds")
-            generate_ids.Update()
-            outData.ShallowCopy(generate_ids.GetOutput())
-            # we have to deep copy the cell array because we modify it
-            # with RemoveGhostCells
-            cells = vtkCellArray()
-            cell_types = vtkUnsignedCharArray()
-            cells.DeepCopy(outData.GetCells())
-            cell_types.DeepCopy(outData.GetCellTypesArray())
-            outData.SetCells(cell_types, cells)
-
-            # compute the new bounds by trimming the inData bounds
-            bounds = list(inData.GetBounds())
-            bounds[0] = bounds[0] + self.trim_lon[0]
-            bounds[1] = bounds[1] - self.trim_lon[1]
-            bounds[2] = bounds[2] + self.trim_lat[0]
-            bounds[3] = bounds[3] - self.trim_lat[1]
-
-            # add HIDDENCELL based on bounds
-            outside_mask = (
-                (cc[:, 0] < bounds[0])
-                | (cc[:, 0] > bounds[1])
-                | (cc[:, 1] < bounds[2])
-                | (cc[:, 1] > bounds[3])
-            )
-            # Create ghost array (0 = visible, HIDDENCELL = invisible)
-            ghost_np = np.where(
-                outside_mask, vtkDataSetAttributes.HIDDENCELL, 0
-            ).astype(np.uint8)
-
-            # Convert to VTK and add to output
-            ghost = numpy_support.numpy_to_vtk(ghost_np)
-            ghost.SetName(vtkDataSetAttributes.GhostArrayName())
-            outData.GetCellData().AddArray(ghost)
-            outData.RemoveGhostCells()
-
-            self._cached_output = outData.NewInstance()
-            self._cached_output.ShallowCopy(outData)
-        self._last_was_trimmed = True
-        return 1
 
 
 @smproxy.filter()
@@ -742,52 +772,59 @@ class EAMCenterMeridian(VTKPythonAlgorithmBase):
         return self._center_meridian
 
     def RequestData(self, request, inInfo, outInfo):
-        inData = self.GetInputData(inInfo, 0, 0)
+        with _perf.timed("center_meridian.RequestData"):
+            inData = self.GetInputData(inInfo, 0, 0)
 
-        outData = self.GetOutputData(outInfo, 0)
-        if (
-            self._cached_output
-            and self._cached_output.GetPoints().GetMTime()
-            >= inData.GetPoints().GetMTime()
-            and self._cached_output.GetCells().GetMTime()
-            >= inData.GetCells().GetMTime()
-        ):
-            add_cell_arrays(inData, outData, self._cached_output)
-        else:
-            generate_ids = vtkGenerateIds()
-            generate_ids.SetInputData(inData)
-            generate_ids.PointIdsOff()
-            generate_ids.SetCellIdsArrayName("PedigreeIds")
+            outData = self.GetOutputData(outInfo, 0)
+            if (
+                self._cached_output
+                and self._cached_output.GetPoints().GetMTime()
+                >= inData.GetPoints().GetMTime()
+                and self._cached_output.GetCells().GetMTime()
+                >= inData.GetCells().GetMTime()
+            ):
+                with _perf.timed("center_meridian.cache_hit"):
+                    add_cell_arrays(inData, outData, self._cached_output)
+            else:
+                with _perf.timed("center_meridian.rebuild"):
+                    generate_ids = vtkGenerateIds()
+                    generate_ids.SetInputData(inData)
+                    generate_ids.PointIdsOff()
+                    generate_ids.SetCellIdsArrayName("PedigreeIds")
 
-            cut_meridian = self._center_meridian + 180
-            plane = vtkPlane()
-            plane.SetOrigin([cut_meridian, 0.0, 0.0])
-            plane.SetNormal([-1, 0, 0])
-            # vtkClipPolyData hangs
-            clipL = vtkTableBasedClipDataSet()
-            clipL.SetClipFunction(plane)
-            clipL.SetInputConnection(generate_ids.GetOutputPort())
-            clipL.Update()
+                    cut_meridian = self._center_meridian + 180
+                    plane = vtkPlane()
+                    plane.SetOrigin([cut_meridian, 0.0, 0.0])
+                    plane.SetNormal([-1, 0, 0])
+                    # vtkClipPolyData hangs
+                    clipL = vtkTableBasedClipDataSet()
+                    clipL.SetClipFunction(plane)
+                    clipL.SetInputConnection(generate_ids.GetOutputPort())
+                    with _perf.timed("center_meridian.clip_left"):
+                        clipL.Update()
 
-            plane.SetNormal([1, 0, 0])
-            clipR = vtkTableBasedClipDataSet()
-            clipR.SetClipFunction(plane)
-            clipR.SetInputConnection(generate_ids.GetOutputPort())
-            clipR.Update()
+                    plane.SetNormal([1, 0, 0])
+                    clipR = vtkTableBasedClipDataSet()
+                    clipR.SetClipFunction(plane)
+                    clipR.SetInputConnection(generate_ids.GetOutputPort())
+                    with _perf.timed("center_meridian.clip_right"):
+                        clipR.Update()
 
-            transFunc = vtkTransform()
-            transFunc.Translate(-360, 0, 0)
-            transform = vtkTransformFilter()
-            transform.SetInputData(clipR.GetOutput())
-            transform.SetTransform(transFunc)
-            transform.Update()
+                    transFunc = vtkTransform()
+                    transFunc.Translate(-360, 0, 0)
+                    transform = vtkTransformFilter()
+                    transform.SetInputData(clipR.GetOutput())
+                    transform.SetTransform(transFunc)
+                    with _perf.timed("center_meridian.transform"):
+                        transform.Update()
 
-            append = vtkAppendFilter()
-            append.AddInputData(clipL.GetOutput())
-            append.AddInputData(transform.GetOutput())
-            append.Update()
-            outData.ShallowCopy(append.GetOutput())
-            # previous _cached_output is available for garbage collection
-            self._cached_output = outData.NewInstance()
-            self._cached_output.ShallowCopy(outData)
-        return 1
+                    append = vtkAppendFilter()
+                    append.AddInputData(clipL.GetOutput())
+                    append.AddInputData(transform.GetOutput())
+                    with _perf.timed("center_meridian.append"):
+                        append.Update()
+                    outData.ShallowCopy(append.GetOutput())
+                    # previous _cached_output is available for garbage collection
+                    self._cached_output = outData.NewInstance()
+                    self._cached_output.ShallowCopy(outData)
+            return 1

--- a/src/e3sm_quickview/plugins/eam_reader.py
+++ b/src/e3sm_quickview/plugins/eam_reader.py
@@ -19,6 +19,23 @@ except ImportError as ie:
     )
     _has_deps = False
 
+try:
+    from e3sm_quickview.utils import perf as _perf
+except ImportError:
+    # Plugin may be loaded by paraview with quickview not on sys.path; fall
+    # back to a no-op shim so the reader still works.
+    from contextlib import contextmanager
+
+    class _perf:  # type: ignore[no-redef]
+        @staticmethod
+        def is_enabled():
+            return False
+
+        @staticmethod
+        @contextmanager
+        def timed(label):
+            yield
+
 # Dimensions will be dynamically determined from connectivity and data files
 
 
@@ -422,11 +439,13 @@ class EAMSliceSource(VTKPythonAlgorithmBase):
                     # Use all data for unspecified dimensions
                     slice_tuple.append(self._slices.get(dim, 0))
 
-            # Get data with proper slicing
-            data = vardata[varmeta.name][tuple(slice_tuple)].data.reshape(-1)
+            with _perf.timed(f"reader.netcdf_read.{varmeta.name}"):
+                # Get data with proper slicing
+                data = vardata[varmeta.name][tuple(slice_tuple)].data.reshape(-1)
             if not np.isnan(varmeta.fillval):
-                data = data.copy()
-                data[data == varmeta.fillval] = np.nan
+                with _perf.timed(f"reader.fill_value_scan.{varmeta.name}"):
+                    data = data.copy()
+                    data[data == varmeta.fillval] = np.nan
             return data
         except Exception as e:
             print_error(f"Error loading variable {varmeta.name}: {e}")
@@ -710,6 +729,10 @@ class EAMSliceSource(VTKPythonAlgorithmBase):
         return timeInd
 
     def RequestData(self, request, inInfo, outInfo):
+        with _perf.timed("reader.RequestData"):
+            return self._RequestDataImpl(request, inInfo, outInfo)
+
+    def _RequestDataImpl(self, request, inInfo, outInfo):
         if (
             self._ConnFileName is None
             or self._ConnFileName == "None"

--- a/src/e3sm_quickview/utils/cli.py
+++ b/src/e3sm_quickview/utils/cli.py
@@ -37,5 +37,13 @@ def configure_and_parse(parser):
         action="store_true",
         help="Use a single vtkRenderWindow to share GPU memory",
     )
+    parser.add_argument(
+        "--perf",
+        dest="perf",
+        action="store_true",
+        help="Emit performance timing on stderr ([PERF] lines). Used to "
+        "diagnose where slider-tick cost is going — reader I/O, pipeline, "
+        "rendering, web layer, etc.",
+    )
 
     return parser.parse_known_args()[0]

--- a/src/e3sm_quickview/utils/compute.py
+++ b/src/e3sm_quickview/utils/compute.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 import numpy as np
 
+from e3sm_quickview.utils import perf
+
 
 def calculate_weighted_average(
     data_array: np.ndarray, weights: Optional[np.ndarray] = None
@@ -41,9 +43,10 @@ def extract_avgs(vtk_data, array_names):
         if vtk_array is None:
             results[name] = np.nan
             continue
-        if area_array:
-            avg_value = calculate_weighted_average(vtk_array, area_array)
-        else:
-            avg_value = float(np.nanmean(np.array(vtk_array)))
+        with perf.timed(f"extract_avgs.{name}"):
+            if area_array:
+                avg_value = calculate_weighted_average(vtk_array, area_array)
+            else:
+                avg_value = float(np.nanmean(np.array(vtk_array)))
         results[name] = avg_value
     return results

--- a/src/e3sm_quickview/utils/perf.py
+++ b/src/e3sm_quickview/utils/perf.py
@@ -52,3 +52,60 @@ def log(label: str, ms: float) -> None:
     """Record a timing measured elsewhere (e.g. via a callback)."""
     if _ENABLED:
         print(f"[PERF] {label}: {ms:8.2f} ms", file=sys.stderr, flush=True)
+
+
+def _install_trame_rca_hooks():
+    """Monkey-patch trame_rca so encode + push phases show up under --perf.
+
+    Installed once at module import. Wrappers check _ENABLED per-call; no
+    overhead when perf is off beyond the bool test.
+
+    Emits:
+        [PERF] rca.encode.<encoder>: <ms> ms    (per encode, thread-pool)
+        [PERF] rca.push.<area>:     <ms> ms    (per websocket push)
+    """
+    try:
+        from trame_rca.utils import RcaEncoder, RcaViewAdapter
+    except ImportError:
+        return
+
+    _orig_encode = RcaEncoder.encode
+
+    def _timed_encode(self, np_image, cols, rows, quality):
+        if not _ENABLED:
+            return _orig_encode(self, np_image, cols, rows, quality)
+        t0 = time.perf_counter()
+        try:
+            return _orig_encode(self, np_image, cols, rows, quality)
+        finally:
+            dt_ms = (time.perf_counter() - t0) * 1000.0
+            print(
+                f"[PERF] rca.encode.{self.value}: {dt_ms:8.2f} ms",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    RcaEncoder.encode = _timed_encode
+
+    _orig_push = RcaViewAdapter.push
+
+    def _timed_push(self, content, meta):
+        if not _ENABLED:
+            return _orig_push(self, content, meta)
+        t0 = time.perf_counter()
+        try:
+            return _orig_push(self, content, meta)
+        finally:
+            dt_ms = (time.perf_counter() - t0) * 1000.0
+            print(
+                f"[PERF] rca.push.{self.area_name}: {dt_ms:8.2f} ms",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    RcaViewAdapter.push = _timed_push
+
+
+# Install RCA hooks eagerly at import. The wrappers are near-free when
+# instrumentation is disabled (one bool check per call site).
+_install_trame_rca_hooks()

--- a/src/e3sm_quickview/utils/perf.py
+++ b/src/e3sm_quickview/utils/perf.py
@@ -1,0 +1,54 @@
+"""Optional performance instrumentation.
+
+Disabled by default. Enable via the ``--perf`` CLI flag (or ``perf.enable()``
+for tests/benchmarks). When enabled, instrumented code paths emit
+
+    [PERF] <label>: <elapsed_ms> ms
+
+to stderr. When disabled the cost is a single module-level bool read per
+call site, so it is safe to leave the timers in production code.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from contextlib import contextmanager
+
+_ENABLED = False
+
+
+def enable(value: bool = True) -> None:
+    """Turn performance instrumentation on or off globally."""
+    global _ENABLED
+    _ENABLED = bool(value)
+
+
+def is_enabled() -> bool:
+    return _ENABLED
+
+
+@contextmanager
+def timed(label: str):
+    """Time a scoped block.
+
+    Emits ``[PERF] <label>: <ms> ms`` on exit when instrumentation is on.
+    No-op otherwise. Works for both sync and async scopes — the context
+    manager itself doesn't need to be async-aware because it's used with
+    ``with``, not ``async with``.
+    """
+    if not _ENABLED:
+        yield
+        return
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        dt_ms = (time.perf_counter() - t0) * 1000.0
+        print(f"[PERF] {label}: {dt_ms:8.2f} ms", file=sys.stderr, flush=True)
+
+
+def log(label: str, ms: float) -> None:
+    """Record a timing measured elsewhere (e.g. via a callback)."""
+    if _ENABLED:
+        print(f"[PERF] {label}: {ms:8.2f} ms", file=sys.stderr, flush=True)

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -12,6 +12,7 @@ from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
 
 from e3sm_quickview.components import view as tview
 from e3sm_quickview.presets import COLOR_BLIND_SAFE
+from e3sm_quickview.utils import perf
 from e3sm_quickview.utils.color import COLORBAR_CACHE, lut_to_img
 from e3sm_quickview.utils.math import compute_color_ticks, tick_contrast_color
 
@@ -142,7 +143,8 @@ class VariableView(TrameComponent):
     def render(self):
         if self.disable_render or not self.ctx.has(self.name):
             return
-        self.ctx[self.name].update()
+        with perf.timed(f"view.{self.variable_name}.render"):
+            self.ctx[self.name].update()
 
     def set_camera_modified(self, fn):
         self._observer = self.camera.AddObserver("ModifiedEvent", fn)
@@ -299,37 +301,39 @@ class VariableView(TrameComponent):
         return ds.GetCellData().GetArray(self.variable_name)
 
     def update_color_range(self, *_):
-        if self.config.override_range:
-            skip_update = False
-            if math.isnan(self.config.color_range[0]):
-                skip_update = True
-                self.config.color_value_min_valid = False
+        with perf.timed(f"view.{self.variable_name}.update_color_range"):
+            if self.config.override_range:
+                skip_update = False
+                if math.isnan(self.config.color_range[0]):
+                    skip_update = True
+                    self.config.color_value_min_valid = False
 
-            if math.isnan(self.config.color_range[1]):
-                skip_update = True
-                self.config.color_value_max_valid = False
+                if math.isnan(self.config.color_range[1]):
+                    skip_update = True
+                    self.config.color_value_max_valid = False
 
-            if skip_update:
-                return
+                if skip_update:
+                    return
 
-            self.lut.RescaleTransferFunction(*self.config.color_range)
-        else:
-            data_array = self.data_array
-            if data_array:
-                data_range = data_array.GetRange()
-                self.config.color_range = data_range
-                self.config.color_value_min = str(data_range[0])
-                self.config.color_value_max = str(data_range[1])
-                self.config.color_value_min_valid = True
-                self.config.color_value_max_valid = True
-                self.lut.RescaleTransferFunction(*data_range)
+                self.lut.RescaleTransferFunction(*self.config.color_range)
+            else:
+                data_array = self.data_array
+                if data_array:
+                    with perf.timed(f"view.{self.variable_name}.get_range"):
+                        data_range = data_array.GetRange()
+                    self.config.color_range = data_range
+                    self.config.color_value_min = str(data_range[0])
+                    self.config.color_value_max = str(data_range[1])
+                    self.config.color_value_min_valid = True
+                    self.config.color_value_max_valid = True
+                    self.lut.RescaleTransferFunction(*data_range)
 
-        self.update_color_preset(
-            self.config.preset,
-            self.config.invert,
-            self.config.use_log_scale,
-            self.config.n_colors,
-        )
+            self.update_color_preset(
+                self.config.preset,
+                self.config.invert,
+                self.config.use_log_scale,
+                self.config.n_colors,
+            )
 
     def _compute_ticks(self):
         vmin, vmax = self.config.color_range

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -1,4 +1,5 @@
 import math
+import time
 
 import numpy as np
 
@@ -98,6 +99,16 @@ class VariableView(TrameComponent):
         self.render_window = self.view.GetRenderWindow()
         self.render_window.SetOffScreenRendering(True)
 
+        # Perf: time the actual VTK render. The `render()` method only
+        # calls `ctx[name].update()` which schedules a trame/RCA push,
+        # so the `view.<var>.render` timer doesn't capture the work of
+        # the render window itself. Observers on Start/EndEvent fire
+        # for every VTK render (triggered by RCA, camera change, etc.)
+        # and emit `view.<var>.render_window` with the elapsed time.
+        self._render_t0 = None
+        self.render_window.AddObserver("StartEvent", self._on_render_start)
+        self.render_window.AddObserver("EndEvent", self._on_render_end)
+
         input = source.data_reader.vtk_geometry
         self.mapper = vtkPolyDataMapper(input_connection=input.output_port)
         self.actor = vtkActor(mapper=self.mapper)
@@ -145,6 +156,16 @@ class VariableView(TrameComponent):
             return
         with perf.timed(f"view.{self.variable_name}.render"):
             self.ctx[self.name].update()
+
+    def _on_render_start(self, *_):
+        if perf.is_enabled():
+            self._render_t0 = time.perf_counter()
+
+    def _on_render_end(self, *_):
+        if perf.is_enabled() and self._render_t0 is not None:
+            dt_ms = (time.perf_counter() - self._render_t0) * 1000.0
+            perf.log(f"view.{self.variable_name}.render_window", dt_ms)
+            self._render_t0 = None
 
     def set_camera_modified(self, fn):
         self._observer = self.camera.AddObserver("ModifiedEvent", fn)

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -1,5 +1,6 @@
 import asyncio
 import math
+import time
 
 import numpy as np
 
@@ -27,6 +28,7 @@ from vtkmodules.vtkRenderingCore import (
 
 from e3sm_quickview.components import view as tview
 from e3sm_quickview.presets import COLOR_BLIND_SAFE
+from e3sm_quickview.utils import perf
 from e3sm_quickview.utils.color import COLORBAR_CACHE, lut_to_img
 from e3sm_quickview.utils.math import compute_color_ticks, tick_contrast_color
 
@@ -468,6 +470,13 @@ class ViewManager(TrameComponent):
         self._camera = vtkCamera(parallel_projection=1)
         self._render_window = vtkRenderWindow()
         self._render_window.OffScreenRenderingOn()
+
+        # Perf: time the actual VTK render on the shared render window.
+        # Emits `view.shared.render_window` with the elapsed time for
+        # each render. See VariableView._on_render_* in view_manager.py.
+        self._render_t0 = None
+        self._render_window.AddObserver("StartEvent", self._on_render_start)
+        self._render_window.AddObserver("EndEvent", self._on_render_end)
         self._style = vtkPVInteractorStyle()
         self._style.AddManipulator(
             vtkPVTrackballZoom(
@@ -519,6 +528,16 @@ class ViewManager(TrameComponent):
         # Sort lists
         self.state.luts_normal.sort(key=lut_name)
         self.state.luts_inverted.sort(key=lut_name)
+
+    def _on_render_start(self, *_):
+        if perf.is_enabled():
+            self._render_t0 = time.perf_counter()
+
+    def _on_render_end(self, *_):
+        if perf.is_enabled() and self._render_t0 is not None:
+            dt_ms = (time.perf_counter() - self._render_t0) * 1000.0
+            perf.log("view.shared.render_window", dt_ms)
+            self._render_t0 = None
 
     def refresh_ui(self, **_):
         for view in self._var2view.values():


### PR DESCRIPTION
Adds an opt-in `--perf` CLI flag that turns on `[PERF] <label>: <ms> ms` timing on stderr across the full server-side slider-tick path, plus a no-op shim so instrumented code paths are near-free (one bool check per call site) when the flag is off. Motivated by a user report of ~2 s/tick on a NERSC cloud instance — we want a way to confirm (or rule out) I/O, rendering, and the web-streaming layer without running a profiler.

Three commits:

1. `2cc8f34` — new `utils/perf.py` module, `--perf` flag wired through CLI, timers around every logical tick stage: `tick.pipeline` / `tick.color_range` / `tick.render` / `tick.extract_avgs`, per-variable `reader.netcdf_read.<var>` + `reader.fill_value_scan.<var>`, all three Python filters (`center_meridian` / `extract` / `project`) with cache-hit vs. rebuild breakdowns, `add_cell_arrays` slice-plan + per-variable pedigree copy, per-view render + color-range, and per-variable `extract_avgs`.

2. `cfee690` — the existing `view.<var>.render` timer only wrapped `ctx[name].update()` (non-blocking trigger), so it reported ~0 ms. Added Start/EndEvent observers on the render window in both view managers that emit `view.<var>.render_window` (default) / `view.shared.render_window` (`--fast`) with the actual VTK render time.

3. `16dd8c2` — monkey-patches `trame_rca.RcaEncoder.encode` and `RcaViewAdapter.push` to emit `rca.encode.<encoder>` (turbo-jpeg/jpeg/…) and `rca.push.<area>` per call. Together with the render-window timer, the server-side path is now end-to-end instrumented: pipeline → VTK render → JPEG encode → websocket write.

Local steady-state trace (25M-cell grid, 2 variables, `--fast`):

```
tick.pipeline:               ~114 ms    (reader 90, center_meridian 22, rest 0)
tick.color_range:             ~50 ms    (2 × GetRange on 25M float32)
tick.extract_avgs:            ~40 ms    (2 × weighted average)
tick.total:                  ~203 ms
view.shared.render_window:   ~170 ms    (async, fires after tick returns)
rca.encode.turbo-jpeg:         ~2 ms
rca.push.rca_image_stream_1:   ~0.02 ms (kernel enqueue, not round-trip)
─────────────────────────────────
server wall-clock per scrub: ~370 ms
```

Known blind spot: `rca.push` measures the server-side handoff to the kernel; actual websocket transit to the browser isn't captured. For the NERSC case, `rca.push.*` in the tens/hundreds of ms would indicate a blocked websocket write (back-pressure from a slow client link); `rca.push.*` staying ~0 ms while user-perceived lag is high would point at network round-trip or client-side paint.
