### PR TITLE
Fix log/symlog tick positions and compute linthresh from data smallest real value

### DIFF
--- a/src/e3sm_quickview/utils/math.py
+++ b/src/e3sm_quickview/utils/math.py
@@ -9,6 +9,39 @@ import numpy as np
 from typing import List, Tuple, Optional
 
 
+def calculate_linthresh(data):
+    """Calculate the linear threshold for symlog scaling.
+
+    Excludes machine-error zeros (values within ±2*eps of the data dtype),
+    then returns min(abs(valid)).
+
+    Operates on the original array without copies.
+
+    Args:
+        data: numpy array of data values
+
+    Returns:
+        linthresh value (float), or 1.0 if no valid values exist
+    """
+    eps = np.finfo(data.dtype).eps
+    threshold = 2 * eps
+
+    # Find min |x| > threshold without allocating a copy.
+    # Using where= runs as a tight vectorized C loop, roughly 2-3 orders
+    # of magnitude faster than a Python for loop.
+    min_pos = np.nanmin(data, where=data > threshold, initial=np.inf)
+    # For negatives: max(data) where data < -threshold gives closest to zero
+    max_neg = np.nanmax(data, where=data < -threshold, initial=-np.inf)
+    min_abs = min(min_pos, -max_neg)
+
+    if min_abs == np.inf:
+        linthresh = 1.0
+    else:
+        linthresh = float(min_abs)
+
+    return linthresh
+
+
 def calculate_weighted_average(
     data_array: np.ndarray, weights: Optional[np.ndarray] = None
 ) -> float:
@@ -135,7 +168,7 @@ def normalize_range(
     return new_min + normalized * (new_max - new_min)
 
 
-def get_nice_ticks(vmin, vmax, n, scale="linear"):
+def get_nice_ticks(vmin, vmax, n, scale="linear", linthresh=None):
     """Compute nicely spaced tick values for a given range and scale.
 
     Args:
@@ -178,19 +211,33 @@ def get_nice_ticks(vmin, vmax, n, scale="linear"):
         else:
             raw_ticks = np.array(powers)
     elif scale == "symlog":
-
-        def transform(x, th):
-            return np.sign(x) * np.log10(np.abs(x) / th + 1)
-
-        def inverse(y, th):
-            return np.sign(y) * th * (10 ** np.abs(y) - 1)
-
-        linthresh = max(abs(vmin), abs(vmax)) * 1e-2
-        if linthresh == 0:
+        if linthresh is None:
             linthresh = 1.0
-        t_min, t_max = transform(vmin, linthresh), transform(vmax, linthresh)
-        t_ticks = np.linspace(t_min, t_max, n)
-        raw_ticks = inverse(t_ticks, linthresh)
+        # Use powers of 10 as tick values, matching the LUT breakpoints
+        ticks_set = set()
+        if vmin < 0:
+            lo = max(linthresh, 1e-30)
+            for e in range(
+                int(np.floor(np.log10(lo))), int(np.floor(np.log10(abs(vmin)))) + 1
+            ):
+                val = -(10.0**e)
+                if vmin <= val < 0:
+                    ticks_set.add(val)
+        if vmax > 0:
+            lo = max(linthresh, 1e-30)
+            for e in range(
+                int(np.floor(np.log10(lo))), int(np.floor(np.log10(vmax))) + 1
+            ):
+                val = 10.0**e
+                if 0 < val <= vmax:
+                    ticks_set.add(val)
+        if vmin <= 0 <= vmax:
+            ticks_set.add(0.0)
+        ticks_set.add(vmin)
+        ticks_set.add(vmax)
+        raw_ticks = np.array(sorted(ticks_set))
+        # Skip snap — powers of 10 are already nice
+        return raw_ticks
     else:
         raw_ticks = np.linspace(vmin, vmax, n)
 
@@ -241,54 +288,17 @@ def tick_contrast_color(r, g, b):
     return "#000" if luminance > 0.45 else "#fff"
 
 
-def _position_on_bar(val, vmin, vmax, scale):
-    """Map a data value to a 0-100 percentage position on a linear colorbar.
-
-    For 'linear' scale, position is simply the linear interpolation.
-    For 'log' and 'symlog', the colorbar image is always rendered from the
-    linear LUT, so tick positions must be placed in the *transformed* space
-    to show where data values actually map.
-    """
-    data_range = vmax - vmin
-    if data_range == 0:
-        return 50.0
-
-    if scale == "log":
-        safe_vmin = max(vmin, 1e-15)
-        safe_vmax = max(vmax, 1e-14)
-        safe_val = max(val, safe_vmin)
-        log_min = np.log10(safe_vmin)
-        log_max = np.log10(safe_vmax)
-        log_range = log_max - log_min
-        if log_range == 0:
-            return 50.0
-        return (np.log10(safe_val) - log_min) / log_range * 100
-
-    if scale == "symlog":
-        linthresh = max(abs(vmin), abs(vmax)) * 1e-2
-        if linthresh == 0:
-            linthresh = 1.0
-
-        def _symlog(x):
-            return np.sign(x) * np.log10(np.abs(x) / linthresh + 1)
-
-        s_min = _symlog(vmin)
-        s_max = _symlog(vmax)
-        s_range = s_max - s_min
-        if s_range == 0:
-            return 50.0
-        return float((_symlog(val) - s_min) / s_range * 100)
-
-    # linear
-    return (val - vmin) / data_range * 100
-
-
-def compute_color_ticks(vmin, vmax, scale="linear", n=5, min_gap=7, edge_margin=3):
+def compute_color_ticks(
+    vmin, vmax, scale="linear", n=5, min_gap=7, edge_margin=3, linthresh=None
+):
     """Compute tick marks for a colorbar.
 
-    The colorbar image is always rendered from the linear LUT.  For log and
-    symlog scales, tick *positions* are placed in the transformed space so
-    they line up visually with the correct colours.
+    Tick positions are computed in the space matching the scale:
+    - linear: position = (val - vmin) / (vmax - vmin) * 100
+    - symlog: position = (symlog(val) - symlog(vmin)) / (symlog(vmax) - symlog(vmin)) * 100
+
+    The colorbar image is always the linear preset, so symlog ticks
+    appear at different positions than linear ticks for the same values.
 
     Args:
         vmin: Minimum color range value
@@ -305,14 +315,43 @@ def compute_color_ticks(vmin, vmax, scale="linear", n=5, min_gap=7, edge_margin=
         return []
 
     raw_n = n if scale == "linear" else n * 2
-    ticks = get_nice_ticks(vmin, vmax, raw_n, scale)
+    ticks = get_nice_ticks(vmin, vmax, raw_n, scale, linthresh=linthresh)
+    data_range = vmax - vmin
 
-    # Build candidate list with position in transformed space
+    # Build mapping functions for non-linear tick positions
+    _symlog_fn = None
+    _log_min = _log_max = _log_range = None
+
+    if scale == "symlog":
+        if linthresh is None:
+            linthresh = 1.0
+
+        def _symlog_fn(v):
+            v = np.asarray(v, dtype=float)
+            return np.sign(v) * np.log10(1.0 + np.abs(v) / linthresh)
+
+        s_min = float(_symlog_fn(vmin))
+        s_max = float(_symlog_fn(vmax))
+        s_range = s_max - s_min
+
+    elif scale == "log":
+        safe_vmin = max(vmin, 1e-30)
+        safe_vmax = max(vmax, 1e-30)
+        _log_min = np.log10(safe_vmin)
+        _log_max = np.log10(safe_vmax)
+        _log_range = _log_max - _log_min
+
+    # Build candidate list with position in the appropriate space
     candidates = []
     has_zero = False
     for t in ticks:
         val = float(t)
-        pos = _position_on_bar(val, vmin, vmax, scale)
+        if scale == "symlog" and s_range != 0:
+            pos = (float(_symlog_fn(val)) - s_min) / s_range * 100
+        elif scale == "log" and _log_range and _log_range != 0 and val > 0:
+            pos = (np.log10(val) - _log_min) / _log_range * 100
+        else:
+            pos = (val - vmin) / data_range * 100
         if edge_margin <= pos <= (100 - edge_margin):
             is_zero = np.isclose(val, 0, atol=1e-12)
             if is_zero:
@@ -327,7 +366,10 @@ def compute_color_ticks(vmin, vmax, scale="linear", n=5, min_gap=7, edge_margin=
 
     # Always include 0 when it falls within the range (for any scale)
     if not has_zero and scale != "log":
-        zero_pos = _position_on_bar(0.0, vmin, vmax, scale)
+        if scale == "symlog" and s_range != 0:
+            zero_pos = (float(_symlog_fn(0.0)) - s_min) / s_range * 100
+        else:
+            zero_pos = (0.0 - vmin) / data_range * 100
         if 0 <= zero_pos <= 100:
             tick = {"position": round(zero_pos, 2), "label": "0", "priority": True}
             # Insert in sorted order

--- a/src/e3sm_quickview/utils/math.py
+++ b/src/e3sm_quickview/utils/math.py
@@ -12,7 +12,7 @@ from typing import List, Tuple, Optional
 def calculate_linthresh(data):
     """Calculate the linear threshold for symlog scaling.
 
-    Excludes machine-error zeros (values within ±2*eps of the data dtype),
+    Excludes machine-error zeros (values within ±sqrt(eps) of the data dtype),
     then returns min(abs(valid)).
 
     Operates on the original array without copies.
@@ -21,10 +21,10 @@ def calculate_linthresh(data):
         data: numpy array of data values
 
     Returns:
-        linthresh value (float), or 1.0 if no valid values exist
+        linthresh value (float), clamped to at least 1.0
     """
     eps = np.finfo(data.dtype).eps
-    threshold = 2 * eps
+    threshold = np.sqrt(eps)
 
     # Find min |x| > threshold without allocating a copy.
     # Using where= runs as a tight vectorized C loop, roughly 2-3 orders
@@ -37,7 +37,7 @@ def calculate_linthresh(data):
     if min_abs == np.inf:
         linthresh = 1.0
     else:
-        linthresh = float(min_abs)
+        linthresh = max(float(min_abs), 1.0)
 
     return linthresh
 
@@ -196,8 +196,9 @@ def get_nice_ticks(vmin, vmax, n, scale="linear", linthresh=None):
         raw_ticks = np.linspace(vmin, vmax, n)
     elif scale == "log":
         # Use integer powers of 10 that fall strictly inside [vmin, vmax]
-        safe_vmin = max(vmin, 1e-15)
-        safe_vmax = max(vmax, 1e-14)
+        log_floor = linthresh if linthresh is not None else 1e-15
+        safe_vmin = max(vmin, log_floor)
+        safe_vmax = max(vmax, log_floor)
         start_exp = int(np.floor(np.log10(safe_vmin)))
         stop_exp = int(np.ceil(np.log10(safe_vmax)))
         powers = [
@@ -328,15 +329,21 @@ def compute_color_ticks(
 
         def _symlog_fn(v):
             v = np.asarray(v, dtype=float)
-            return np.sign(v) * np.log10(1.0 + np.abs(v) / linthresh)
+            abs_v = np.abs(v)
+            return np.where(
+                abs_v > linthresh,
+                np.sign(v) * np.log10(np.maximum(abs_v, linthresh)),
+                v / linthresh * np.log10(linthresh),
+            )
 
         s_min = float(_symlog_fn(vmin))
         s_max = float(_symlog_fn(vmax))
         s_range = s_max - s_min
 
     elif scale == "log":
-        safe_vmin = max(vmin, 1e-30)
-        safe_vmax = max(vmax, 1e-30)
+        log_floor = linthresh if linthresh is not None else 1e-30
+        safe_vmin = max(vmin, log_floor)
+        safe_vmax = max(vmax, log_floor)
         _log_min = np.log10(safe_vmin)
         _log_max = np.log10(safe_vmax)
         _log_range = _log_max - _log_min

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -175,12 +175,13 @@ class VariableView(TrameComponent):
         self.config.effective_color_range = ctf.GetRange()
         self.config.lut_img = lut_to_img(self.lut)
 
-        # Rebuild LUT with non-linear control points, sampling RGB from
-        # the linear colorbar.  Compute linthresh once from data for symlog.
+        # Save a reference to the linear LUT range for tick contrast sampling
+        linear_rgb_points = list(self.lut.RGBPoints)
+
+        # Compute linthresh (smallest positive non-zero value) from data
+        # for log and symlog scales.
         linthresh = None
-        if log_scale == "log":
-            self._apply_log_to_lut()
-        elif log_scale == "symlog":
+        if log_scale in ("log", "symlog"):
             from vtkmodules.util.numpy_support import vtk_to_numpy
 
             arr = self.data_array
@@ -188,9 +189,13 @@ class VariableView(TrameComponent):
                 linthresh = calculate_linthresh(vtk_to_numpy(arr))
             else:
                 linthresh = 1.0
+
+        if log_scale == "log":
+            self._apply_log_to_lut(linthresh)
+        elif log_scale == "symlog":
             self._apply_symlog_to_lut(linthresh)
 
-        self._compute_ticks(linthresh=linthresh)
+        self._compute_ticks(linthresh=linthresh, linear_rgb_points=linear_rgb_points)
 
         # Force mapper to pick up LUT changes
         ctf = self.lut.GetClientSideObject()
@@ -206,10 +211,11 @@ class VariableView(TrameComponent):
         if invert:
             self.lut.InvertTransferFunction()
 
-    def _apply_log_to_lut(self):
+    def _apply_log_to_lut(self, linthresh):
         """Transform the already-prepared LUT to log scale.
 
-        Log scale requires all positive values, so clamp the range if needed.
+        Uses linthresh (smallest positive non-zero data value) as the floor
+        when the range includes zero or negative values.
         The colorbar image is captured before this call, so it stays linear.
         """
         ctf = self.lut.GetClientSideObject()
@@ -217,7 +223,7 @@ class VariableView(TrameComponent):
         if x_max <= 0:
             return
         if x_min <= 0:
-            x_min = x_max * 1e-6
+            x_min = linthresh
             self.lut.RescaleTransferFunction(x_min, x_max)
         self.lut.MapControlPointsToLogSpace()
         self.lut.UseLogScale = 1
@@ -238,29 +244,41 @@ class VariableView(TrameComponent):
 
         def symlog(v):
             v = np.asarray(v, dtype=float)
-            return np.sign(v) * np.log10(1.0 + np.abs(v) / linthresh)
+            abs_v = np.abs(v)
+            return np.where(
+                abs_v > linthresh,
+                np.sign(v) * np.log10(np.maximum(abs_v, linthresh)),
+                v / linthresh * np.log10(linthresh),
+            )
 
-        # Build decade breakpoints
+        # Build control points: N uniform samples in symlog space, plus
+        # mandatory breakpoints at ±linthresh and 0 for exact transitions.
+        n_samples = 1024
+        s_min_val = float(symlog(x_min))
+        s_max_val = float(symlog(x_max))
+        s_range_bp = s_max_val - s_min_val
+        if s_range_bp == 0:
+            return
+
+        # Uniform in symlog space → invert to data space
+        s_vals = np.linspace(s_min_val, s_max_val, n_samples)
         breakpoints = set()
+        for s in s_vals:
+            # Invert symlog: if |s| > log10(linthresh), v = sign(s)*10^|s|
+            #                else v = s / log10(linthresh) * linthresh
+            log_lt = np.log10(linthresh) if linthresh > 0 else 0.0
+            if log_lt != 0 and abs(s) <= abs(log_lt):
+                v = s / log_lt * linthresh
+            elif s > 0:
+                v = 10.0**s
+            elif s < 0:
+                v = -(10.0 ** abs(s))
+            else:
+                v = 0.0
+            if x_min <= v <= x_max:
+                breakpoints.add(v)
 
-        if x_min < 0:
-            lo = max(linthresh, 1e-30)
-            for e in range(
-                int(np.floor(np.log10(lo))), int(np.floor(np.log10(abs(x_min)))) + 1
-            ):
-                val = -(10.0**e)
-                if x_min <= val < 0:
-                    breakpoints.add(val)
-
-        if x_max > 0:
-            lo = max(linthresh, 1e-30)
-            for e in range(
-                int(np.floor(np.log10(lo))), int(np.floor(np.log10(x_max))) + 1
-            ):
-                val = 10.0**e
-                if 0 < val <= x_max:
-                    breakpoints.add(val)
-
+        # Mandatory breakpoints for exact linear↔log transitions
         if x_min < 0 and x_max > 0:
             breakpoints.update((-linthresh, 0.0, linthresh))
         elif x_min < 0 and x_max <= 0:
@@ -269,6 +287,8 @@ class VariableView(TrameComponent):
         elif x_min >= 0 and x_max > 0:
             if linthresh <= x_max:
                 breakpoints.add(linthresh)
+        if x_min <= 0 <= x_max:
+            breakpoints.add(0.0)
 
         breakpoints.add(x_min)
         breakpoints.add(x_max)
@@ -349,28 +369,38 @@ class VariableView(TrameComponent):
             self.config.n_colors,
         )
 
-    def _compute_ticks(self, linthresh=None):
+    def _compute_ticks(self, linthresh=None, linear_rgb_points=None):
         vmin, vmax = self.config.color_range
         ticks = compute_color_ticks(
             vmin, vmax, scale=self.config.use_log_scale, n=5, linthresh=linthresh
         )
-        # Sample colors exactly as lut_to_img does: use RGBPoints range
-        rgb_points = self.lut.RGBPoints
+        # Sample colors from the *linear* LUT so tick contrast matches the
+        # displayed colorbar image, not the log/symlog-remapped rendering LUT.
+        rgb_points = (
+            linear_rgb_points if linear_rgb_points else list(self.lut.RGBPoints)
+        )
         if len(rgb_points) < 4:
             self.config.color_ticks = []
             return
-        ctf = self.lut.GetClientSideObject()
-        rgb = [0.0, 0.0, 0.0]
         img_min = rgb_points[0]
         img_max = rgb_points[-4]
         img_range = img_max - img_min
         if img_range == 0:
             self.config.color_ticks = []
             return
+        # Build a temporary linear CTF to sample colors from
+        from vtkmodules.vtkRenderingCore import vtkColorTransferFunction
+
+        linear_ctf = vtkColorTransferFunction()
+        for i in range(0, len(rgb_points), 4):
+            linear_ctf.AddRGBPoint(
+                rgb_points[i], rgb_points[i + 1], rgb_points[i + 2], rgb_points[i + 3]
+            )
+        rgb = [0.0, 0.0, 0.0]
         for tick in ticks:
             t = tick["position"] / 100.0
             value = img_min + t * img_range
-            ctf.GetColor(value, rgb)
+            linear_ctf.GetColor(value, rgb)
             tick["color"] = tick_contrast_color(rgb[0], rgb[1], rgb[2])
         self.config.color_ticks = ticks
 

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -1,7 +1,7 @@
 import math
-import time
 
 import numpy as np
+
 from paraview import simple
 from trame.app import TrameComponent, dataclass
 from trame.decorators import controller
@@ -12,9 +12,12 @@ from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
 
 from e3sm_quickview.components import view as tview
 from e3sm_quickview.presets import COLOR_BLIND_SAFE
-from e3sm_quickview.utils import perf
 from e3sm_quickview.utils.color import COLORBAR_CACHE, lut_to_img
-from e3sm_quickview.utils.math import compute_color_ticks, tick_contrast_color
+from e3sm_quickview.utils.math import (
+    calculate_linthresh,
+    compute_color_ticks,
+    tick_contrast_color,
+)
 
 
 def auto_size_to_col(size):
@@ -98,16 +101,6 @@ class VariableView(TrameComponent):
         self.render_window = self.view.GetRenderWindow()
         self.render_window.SetOffScreenRendering(True)
 
-        # Perf: time the actual VTK render. The `render()` method only
-        # calls `ctx[name].update()` which schedules a trame/RCA push,
-        # so the `view.<var>.render` timer doesn't capture the work of
-        # the render window itself. Observers on Start/EndEvent fire
-        # for every VTK render (triggered by RCA, camera change, etc.)
-        # and emit `view.<var>.render_window` with the elapsed time.
-        self._render_t0 = None
-        self.render_window.AddObserver("StartEvent", self._on_render_start)
-        self.render_window.AddObserver("EndEvent", self._on_render_end)
-
         input = source.data_reader.vtk_geometry
         self.mapper = vtkPolyDataMapper(input_connection=input.output_port)
         self.actor = vtkActor(mapper=self.mapper)
@@ -153,18 +146,7 @@ class VariableView(TrameComponent):
     def render(self):
         if self.disable_render or not self.ctx.has(self.name):
             return
-        with perf.timed(f"view.{self.variable_name}.render"):
-            self.ctx[self.name].update()
-
-    def _on_render_start(self, *_):
-        if perf.is_enabled():
-            self._render_t0 = time.perf_counter()
-
-    def _on_render_end(self, *_):
-        if perf.is_enabled() and self._render_t0 is not None:
-            dt_ms = (time.perf_counter() - self._render_t0) * 1000.0
-            perf.log(f"view.{self.variable_name}.render_window", dt_ms)
-            self._render_t0 = None
+        self.ctx[self.name].update()
 
     def set_camera_modified(self, fn):
         self._observer = self.camera.AddObserver("ModifiedEvent", fn)
@@ -188,21 +170,30 @@ class VariableView(TrameComponent):
         if n_colors is not None:
             self.lut.NumberOfTableValues = n_colors
 
-        # Capture the colorbar image and tick marks from the LINEAR LUT
-        # before any log/symlog transform so the bar always looks linear.
+        # Capture the linear colorbar image (always the same regardless of scale)
+        ctf = self.lut.GetClientSideObject()
+        self.config.effective_color_range = ctf.GetRange()
         self.config.lut_img = lut_to_img(self.lut)
-        self._compute_ticks()
 
+        # Rebuild LUT with non-linear control points, sampling RGB from
+        # the linear colorbar.  Compute linthresh once from data for symlog.
+        linthresh = None
         if log_scale == "log":
             self._apply_log_to_lut()
         elif log_scale == "symlog":
-            self._apply_symlog_to_lut()
+            from vtkmodules.util.numpy_support import vtk_to_numpy
 
-        # Read the actual LUT range (may differ from color_range for log scale)
-        ctf = self.lut.GetClientSideObject()
-        self.config.effective_color_range = ctf.GetRange()
+            arr = self.data_array
+            if arr is not None:
+                linthresh = calculate_linthresh(vtk_to_numpy(arr))
+            else:
+                linthresh = 1.0
+            self._apply_symlog_to_lut(linthresh)
+
+        self._compute_ticks(linthresh=linthresh)
 
         # Force mapper to pick up LUT changes
+        ctf = self.lut.GetClientSideObject()
         self.mapper.SetLookupTable(ctf)
         self.mapper.Modified()
 
@@ -219,6 +210,7 @@ class VariableView(TrameComponent):
         """Transform the already-prepared LUT to log scale.
 
         Log scale requires all positive values, so clamp the range if needed.
+        The colorbar image is captured before this call, so it stays linear.
         """
         ctf = self.lut.GetClientSideObject()
         x_min, x_max = ctf.GetRange()
@@ -230,72 +222,76 @@ class VariableView(TrameComponent):
         self.lut.MapControlPointsToLogSpace()
         self.lut.UseLogScale = 1
 
-    def _apply_symlog_to_lut(
-        self, linthresh=None, linscale=1.0, base=10, n_samples=256
-    ):
-        """Transform the already-prepared LUT to symmetric log scale.
+    def _apply_symlog_to_lut(self, linthresh):
+        """Build a symlog LUT with decade control points.
 
-        Uses:
-        - Linear for |x| <= linthresh
-        - Logarithmic for |x| > linthresh
-        with continuity at the boundary.
-
-        Samples colors from the linear preset and redistributes them
-        across the data range using symlog spacing.
+        Control points are placed at powers of 10 (and ±linthresh, 0 for
+        mixed-sign data).  The RGB color for each control point is sampled
+        from the linear colorbar at the position where that value falls in
+        symlog space: t = (symlog(v) - symlog(min)) / (symlog(max) - symlog(min)).
         """
-        # Get the current data range from the LUT
         ctf = self.lut.GetClientSideObject()
         x_min, x_max = ctf.GetRange()
         data_range = x_max - x_min
         if data_range == 0:
             return
 
-        if linthresh is None:
-            linthresh = max(abs(x_min), abs(x_max)) * 1e-2
-            if linthresh == 0:
-                linthresh = 1.0
+        def symlog(v):
+            v = np.asarray(v, dtype=float)
+            return np.sign(v) * np.log10(1.0 + np.abs(v) / linthresh)
 
-        log_base = np.log(base)
-        linscale_adj = linscale / (1.0 - base**-1)
+        # Build decade breakpoints
+        breakpoints = set()
 
-        def symlog(x):
-            abs_x = np.abs(x)
-            # Clip to avoid log(0); values <= linthresh use linear branch anyway
-            safe_abs = np.maximum(abs_x, linthresh)
-            out = np.where(
-                abs_x <= linthresh,
-                x * linscale_adj,
-                np.sign(x)
-                * linthresh
-                * (linscale_adj + np.log(safe_abs / linthresh) / log_base),
-            )
-            return out
+        if x_min < 0:
+            lo = max(linthresh, 1e-30)
+            for e in range(
+                int(np.floor(np.log10(lo))), int(np.floor(np.log10(abs(x_min)))) + 1
+            ):
+                val = -(10.0**e)
+                if x_min <= val < 0:
+                    breakpoints.add(val)
 
-        # Sample colors from the linear LUT at uniform positions
-        rgb = [0.0, 0.0, 0.0]
-        s_min = symlog(x_min)
-        s_max = symlog(x_max)
+        if x_max > 0:
+            lo = max(linthresh, 1e-30)
+            for e in range(
+                int(np.floor(np.log10(lo))), int(np.floor(np.log10(x_max))) + 1
+            ):
+                val = 10.0**e
+                if 0 < val <= x_max:
+                    breakpoints.add(val)
+
+        if x_min < 0 and x_max > 0:
+            breakpoints.update((-linthresh, 0.0, linthresh))
+        elif x_min < 0 and x_max <= 0:
+            if -linthresh >= x_min:
+                breakpoints.add(-linthresh)
+        elif x_min >= 0 and x_max > 0:
+            if linthresh <= x_max:
+                breakpoints.add(linthresh)
+
+        breakpoints.add(x_min)
+        breakpoints.add(x_max)
+        breakpoints = sorted(breakpoints)
+
+        # Symlog range for normalization
+        s_min = float(symlog(x_min))
+        s_max = float(symlog(x_max))
         s_range = s_max - s_min
         if s_range == 0:
             return
 
+        # Sample RGB from the linear LUT at symlog-normalized positions
+        rgb = [0.0, 0.0, 0.0]
         new_rgb_points = []
-        for i in range(n_samples):
-            # Uniform position in data space
-            t = i / (n_samples - 1)
-            x_data = x_min + t * data_range
-
-            # Map x_data through symlog, normalize to [0,1], then look up
-            # the color at the corresponding linear position
-            s_val = symlog(x_data)
-            s_t = (s_val - s_min) / s_range
-            x_lookup = x_min + s_t * data_range
+        for v in breakpoints:
+            t = (float(symlog(v)) - s_min) / s_range
+            x_lookup = x_min + t * data_range
             ctf.GetColor(x_lookup, rgb)
             new_rgb_points.extend(
-                [float(x_data), float(rgb[0]), float(rgb[1]), float(rgb[2])]
+                [float(v), float(rgb[0]), float(rgb[1]), float(rgb[2])]
             )
 
-        # Write back through the proxy so state stays in sync
         self.lut.RGBPoints = new_rgb_points
 
     def color_range_str_to_float(self, color_value_min, color_value_max):
@@ -321,60 +317,59 @@ class VariableView(TrameComponent):
         return ds.GetCellData().GetArray(self.variable_name)
 
     def update_color_range(self, *_):
-        with perf.timed(f"view.{self.variable_name}.update_color_range"):
-            if self.config.override_range:
-                skip_update = False
-                if math.isnan(self.config.color_range[0]):
-                    skip_update = True
-                    self.config.color_value_min_valid = False
+        if self.config.override_range:
+            skip_update = False
+            if math.isnan(self.config.color_range[0]):
+                skip_update = True
+                self.config.color_value_min_valid = False
 
-                if math.isnan(self.config.color_range[1]):
-                    skip_update = True
-                    self.config.color_value_max_valid = False
+            if math.isnan(self.config.color_range[1]):
+                skip_update = True
+                self.config.color_value_max_valid = False
 
-                if skip_update:
-                    return
+            if skip_update:
+                return
 
-                self.lut.RescaleTransferFunction(*self.config.color_range)
-            else:
-                data_array = self.data_array
-                if data_array:
-                    with perf.timed(f"view.{self.variable_name}.get_range"):
-                        data_range = data_array.GetRange()
-                    self.config.color_range = data_range
-                    self.config.color_value_min = str(data_range[0])
-                    self.config.color_value_max = str(data_range[1])
-                    self.config.color_value_min_valid = True
-                    self.config.color_value_max_valid = True
-                    self.lut.RescaleTransferFunction(*data_range)
+            self.lut.RescaleTransferFunction(*self.config.color_range)
+        else:
+            data_array = self.data_array
+            if data_array:
+                data_range = data_array.GetRange()
+                self.config.color_range = data_range
+                self.config.color_value_min = str(data_range[0])
+                self.config.color_value_max = str(data_range[1])
+                self.config.color_value_min_valid = True
+                self.config.color_value_max_valid = True
+                self.lut.RescaleTransferFunction(*data_range)
 
-            self.update_color_preset(
-                self.config.preset,
-                self.config.invert,
-                self.config.use_log_scale,
-                self.config.n_colors,
-            )
+        self.update_color_preset(
+            self.config.preset,
+            self.config.invert,
+            self.config.use_log_scale,
+            self.config.n_colors,
+        )
 
-    def _compute_ticks(self):
+    def _compute_ticks(self, linthresh=None):
         vmin, vmax = self.config.color_range
-        ticks = compute_color_ticks(vmin, vmax, scale=self.config.use_log_scale, n=5)
-        if not ticks:
+        ticks = compute_color_ticks(
+            vmin, vmax, scale=self.config.use_log_scale, n=5, linthresh=linthresh
+        )
+        # Sample colors exactly as lut_to_img does: use RGBPoints range
+        rgb_points = self.lut.RGBPoints
+        if len(rgb_points) < 4:
             self.config.color_ticks = []
             return
-        # The colorbar image is always rendered from the linear LUT, so
-        # sample contrast colors using the linear color_range.
         ctf = self.lut.GetClientSideObject()
         rgb = [0.0, 0.0, 0.0]
-        cr_min, cr_max = float(vmin), float(vmax)
-        cr_range = cr_max - cr_min
-        if cr_range == 0:
+        img_min = rgb_points[0]
+        img_max = rgb_points[-4]
+        img_range = img_max - img_min
+        if img_range == 0:
             self.config.color_ticks = []
             return
         for tick in ticks:
-            # tick position is already in the correct visual space (0-100%)
             t = tick["position"] / 100.0
-            # Map back to the linear data range to sample the color
-            value = cr_min + t * cr_range
+            value = img_min + t * img_range
             ctf.GetColor(value, rgb)
             tick["color"] = tick_contrast_color(rgb[0], rgb[1], rgb[2])
         self.config.color_ticks = ticks
@@ -390,7 +385,6 @@ class VariableView(TrameComponent):
                     "active_layout !== 'auto_layout' ? `height: calc(100% - ${top_padding}px;` : 'overflow-hidden'",
                 ),
                 tile=("active_layout !== 'auto_layout'",),
-                raw_attrs=[f'data-field-name="{self.variable_name}"'],
             ):
                 with v3.VRow(
                     dense=True,
@@ -447,13 +441,6 @@ class VariableView(TrameComponent):
                         f"fields_avgs['{self.variable_name}']?.toExponential(2) || 'N/A'"
                         "}}",
                         classes="text-caption px-1 text-no-wrap",
-                    )
-                    v3.VIconBtn(
-                        v_tooltip_bottom="'Capture panel as PNG'",
-                        icon="mdi-camera",
-                        size="x-small",
-                        variant="plain",
-                        click=f"utils.quickview.capturePanel('{self.variable_name}', time_idx, midpoint_idx, interface_idx)",
                     )
 
                 with html.Div(
@@ -596,7 +583,6 @@ class ViewManager(TrameComponent):
         # Build a lookup from type name to color from state.variable_types
         type_to_color = {vt["name"]: vt["color"] for vt in self.state.variable_types}
         with DivLayout(self.server, template_name="auto_layout") as self.ui:
-            self.ui.root.classes = "all-variables"
             if self.state.layout_grouped:
                 with v3.VCol(classes="pa-1"):
                     for var_type in variables.keys():

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -192,12 +192,13 @@ class VariableView(TrameComponent):
         self.config.effective_color_range = ctf.GetRange()
         self.config.lut_img = lut_to_img(self.lut)
 
-        # Rebuild LUT with non-linear control points after capturing the
-        # linear colorbar image.  Compute linthresh once from data for symlog.
+        # Save a reference to the linear LUT range for tick contrast sampling
+        linear_rgb_points = list(self.lut.RGBPoints)
+
+        # Compute linthresh (smallest positive non-zero value) from data
+        # for log and symlog scales.
         linthresh = None
-        if log_scale == "log":
-            self._apply_log_to_lut()
-        elif log_scale == "symlog":
+        if log_scale in ("log", "symlog"):
             from vtkmodules.util.numpy_support import vtk_to_numpy
 
             arr = self.data_array
@@ -205,9 +206,13 @@ class VariableView(TrameComponent):
                 linthresh = calculate_linthresh(vtk_to_numpy(arr))
             else:
                 linthresh = 1.0
+
+        if log_scale == "log":
+            self._apply_log_to_lut(linthresh)
+        elif log_scale == "symlog":
             self._apply_symlog_to_lut(linthresh)
 
-        self._compute_ticks(linthresh=linthresh)
+        self._compute_ticks(linthresh=linthresh, linear_rgb_points=linear_rgb_points)
 
         # Force mapper to pick up LUT changes
         ctf = self.lut.GetClientSideObject()
@@ -223,17 +228,19 @@ class VariableView(TrameComponent):
         if invert:
             self.lut.InvertTransferFunction()
 
-    def _apply_log_to_lut(self):
+    def _apply_log_to_lut(self, linthresh):
         """Transform the already-prepared LUT to log scale.
 
-        Log scale requires all positive values, so clamp the range if needed.
+        Uses linthresh (smallest positive non-zero data value) as the floor
+        when the range includes zero or negative values.
+        The colorbar image is captured before this call, so it stays linear.
         """
         ctf = self.lut.GetClientSideObject()
         x_min, x_max = ctf.GetRange()
         if x_max <= 0:
             return
         if x_min <= 0:
-            x_min = x_max * 1e-6
+            x_min = linthresh
             self.lut.RescaleTransferFunction(x_min, x_max)
         self.lut.MapControlPointsToLogSpace()
         self.lut.UseLogScale = 1
@@ -254,29 +261,41 @@ class VariableView(TrameComponent):
 
         def symlog(v):
             v = np.asarray(v, dtype=float)
-            return np.sign(v) * np.log10(1.0 + np.abs(v) / linthresh)
+            abs_v = np.abs(v)
+            return np.where(
+                abs_v > linthresh,
+                np.sign(v) * np.log10(np.maximum(abs_v, linthresh)),
+                v / linthresh * np.log10(linthresh),
+            )
 
-        # Build decade breakpoints
+        # Build control points: N uniform samples in symlog space, plus
+        # mandatory breakpoints at ±linthresh and 0 for exact transitions.
+        n_samples = 1024
+        s_min_val = float(symlog(x_min))
+        s_max_val = float(symlog(x_max))
+        s_range_bp = s_max_val - s_min_val
+        if s_range_bp == 0:
+            return
+
+        # Uniform in symlog space → invert to data space
+        s_vals = np.linspace(s_min_val, s_max_val, n_samples)
         breakpoints = set()
+        for s in s_vals:
+            # Invert symlog: if |s| > log10(linthresh), v = sign(s)*10^|s|
+            #                else v = s / log10(linthresh) * linthresh
+            log_lt = np.log10(linthresh) if linthresh > 0 else 0.0
+            if log_lt != 0 and abs(s) <= abs(log_lt):
+                v = s / log_lt * linthresh
+            elif s > 0:
+                v = 10.0**s
+            elif s < 0:
+                v = -(10.0 ** abs(s))
+            else:
+                v = 0.0
+            if x_min <= v <= x_max:
+                breakpoints.add(v)
 
-        if x_min < 0:
-            lo = max(linthresh, 1e-30)
-            for e in range(
-                int(np.floor(np.log10(lo))), int(np.floor(np.log10(abs(x_min)))) + 1
-            ):
-                val = -(10.0**e)
-                if x_min <= val < 0:
-                    breakpoints.add(val)
-
-        if x_max > 0:
-            lo = max(linthresh, 1e-30)
-            for e in range(
-                int(np.floor(np.log10(lo))), int(np.floor(np.log10(x_max))) + 1
-            ):
-                val = 10.0**e
-                if 0 < val <= x_max:
-                    breakpoints.add(val)
-
+        # Mandatory breakpoints for exact linear↔log transitions
         if x_min < 0 and x_max > 0:
             breakpoints.update((-linthresh, 0.0, linthresh))
         elif x_min < 0 and x_max <= 0:
@@ -285,6 +304,8 @@ class VariableView(TrameComponent):
         elif x_min >= 0 and x_max > 0:
             if linthresh <= x_max:
                 breakpoints.add(linthresh)
+        if x_min <= 0 <= x_max:
+            breakpoints.add(0.0)
 
         breakpoints.add(x_min)
         breakpoints.add(x_max)
@@ -365,28 +386,38 @@ class VariableView(TrameComponent):
             self.config.n_colors,
         )
 
-    def _compute_ticks(self, linthresh=None):
+    def _compute_ticks(self, linthresh=None, linear_rgb_points=None):
         vmin, vmax = self.config.color_range
         ticks = compute_color_ticks(
             vmin, vmax, scale=self.config.use_log_scale, n=5, linthresh=linthresh
         )
-        # Sample colors exactly as lut_to_img does: use RGBPoints range
-        rgb_points = self.lut.RGBPoints
+        # Sample colors from the *linear* LUT so tick contrast matches the
+        # displayed colorbar image, not the log/symlog-remapped rendering LUT.
+        rgb_points = (
+            linear_rgb_points if linear_rgb_points else list(self.lut.RGBPoints)
+        )
         if len(rgb_points) < 4:
             self.config.color_ticks = []
             return
-        ctf = self.lut.GetClientSideObject()
-        rgb = [0.0, 0.0, 0.0]
         img_min = rgb_points[0]
         img_max = rgb_points[-4]
         img_range = img_max - img_min
         if img_range == 0:
             self.config.color_ticks = []
             return
+        # Build a temporary linear CTF to sample colors from
+        from vtkmodules.vtkRenderingCore import vtkColorTransferFunction
+
+        linear_ctf = vtkColorTransferFunction()
+        for i in range(0, len(rgb_points), 4):
+            linear_ctf.AddRGBPoint(
+                rgb_points[i], rgb_points[i + 1], rgb_points[i + 2], rgb_points[i + 3]
+            )
+        rgb = [0.0, 0.0, 0.0]
         for tick in ticks:
             t = tick["position"] / 100.0
             value = img_min + t * img_range
-            ctf.GetColor(value, rgb)
+            linear_ctf.GetColor(value, rgb)
             tick["color"] = tick_contrast_color(rgb[0], rgb[1], rgb[2])
         self.config.color_ticks = ticks
 

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -1,6 +1,5 @@
 import asyncio
 import math
-import time
 
 import numpy as np
 
@@ -28,9 +27,12 @@ from vtkmodules.vtkRenderingCore import (
 
 from e3sm_quickview.components import view as tview
 from e3sm_quickview.presets import COLOR_BLIND_SAFE
-from e3sm_quickview.utils import perf
 from e3sm_quickview.utils.color import COLORBAR_CACHE, lut_to_img
-from e3sm_quickview.utils.math import compute_color_ticks, tick_contrast_color
+from e3sm_quickview.utils.math import (
+    calculate_linthresh,
+    compute_color_ticks,
+    tick_contrast_color,
+)
 
 
 def auto_size_to_col(size):
@@ -185,21 +187,30 @@ class VariableView(TrameComponent):
         if n_colors is not None:
             self.lut.NumberOfTableValues = n_colors
 
-        # Capture the colorbar image and tick marks from the LINEAR LUT
-        # before any log/symlog transform so the bar always looks linear.
+        # Capture the linear colorbar image (always the same regardless of scale)
+        ctf = self.lut.GetClientSideObject()
+        self.config.effective_color_range = ctf.GetRange()
         self.config.lut_img = lut_to_img(self.lut)
-        self._compute_ticks()
 
+        # Rebuild LUT with non-linear control points after capturing the
+        # linear colorbar image.  Compute linthresh once from data for symlog.
+        linthresh = None
         if log_scale == "log":
             self._apply_log_to_lut()
         elif log_scale == "symlog":
-            self._apply_symlog_to_lut()
+            from vtkmodules.util.numpy_support import vtk_to_numpy
 
-        # Read the actual LUT range (may differ from color_range for log scale)
-        ctf = self.lut.GetClientSideObject()
-        self.config.effective_color_range = ctf.GetRange()
+            arr = self.data_array
+            if arr is not None:
+                linthresh = calculate_linthresh(vtk_to_numpy(arr))
+            else:
+                linthresh = 1.0
+            self._apply_symlog_to_lut(linthresh)
+
+        self._compute_ticks(linthresh=linthresh)
 
         # Force mapper to pick up LUT changes
+        ctf = self.lut.GetClientSideObject()
         self.mapper.SetLookupTable(ctf)
         self.mapper.Modified()
 
@@ -227,72 +238,76 @@ class VariableView(TrameComponent):
         self.lut.MapControlPointsToLogSpace()
         self.lut.UseLogScale = 1
 
-    def _apply_symlog_to_lut(
-        self, linthresh=None, linscale=1.0, base=10, n_samples=256
-    ):
-        """Transform the already-prepared LUT to symmetric log scale.
+    def _apply_symlog_to_lut(self, linthresh):
+        """Build a symlog LUT with decade control points.
 
-        Uses:
-        - Linear for |x| <= linthresh
-        - Logarithmic for |x| > linthresh
-        with continuity at the boundary.
-
-        Samples colors from the linear preset and redistributes them
-        across the data range using symlog spacing.
+        Control points are placed at powers of 10 (and ±linthresh, 0 for
+        mixed-sign data).  The RGB color for each control point is sampled
+        from the linear colorbar at the position where that value falls in
+        symlog space: t = (symlog(v) - symlog(min)) / (symlog(max) - symlog(min)).
         """
-        # Get the current data range from the LUT
         ctf = self.lut.GetClientSideObject()
         x_min, x_max = ctf.GetRange()
         data_range = x_max - x_min
         if data_range == 0:
             return
 
-        if linthresh is None:
-            linthresh = max(abs(x_min), abs(x_max)) * 1e-2
-            if linthresh == 0:
-                linthresh = 1.0
+        def symlog(v):
+            v = np.asarray(v, dtype=float)
+            return np.sign(v) * np.log10(1.0 + np.abs(v) / linthresh)
 
-        log_base = np.log(base)
-        linscale_adj = linscale / (1.0 - base**-1)
+        # Build decade breakpoints
+        breakpoints = set()
 
-        def symlog(x):
-            abs_x = np.abs(x)
-            # Clip to avoid log(0); values <= linthresh use linear branch anyway
-            safe_abs = np.maximum(abs_x, linthresh)
-            out = np.where(
-                abs_x <= linthresh,
-                x * linscale_adj,
-                np.sign(x)
-                * linthresh
-                * (linscale_adj + np.log(safe_abs / linthresh) / log_base),
-            )
-            return out
+        if x_min < 0:
+            lo = max(linthresh, 1e-30)
+            for e in range(
+                int(np.floor(np.log10(lo))), int(np.floor(np.log10(abs(x_min)))) + 1
+            ):
+                val = -(10.0**e)
+                if x_min <= val < 0:
+                    breakpoints.add(val)
 
-        # Sample colors from the linear LUT at uniform positions
-        rgb = [0.0, 0.0, 0.0]
-        s_min = symlog(x_min)
-        s_max = symlog(x_max)
+        if x_max > 0:
+            lo = max(linthresh, 1e-30)
+            for e in range(
+                int(np.floor(np.log10(lo))), int(np.floor(np.log10(x_max))) + 1
+            ):
+                val = 10.0**e
+                if 0 < val <= x_max:
+                    breakpoints.add(val)
+
+        if x_min < 0 and x_max > 0:
+            breakpoints.update((-linthresh, 0.0, linthresh))
+        elif x_min < 0 and x_max <= 0:
+            if -linthresh >= x_min:
+                breakpoints.add(-linthresh)
+        elif x_min >= 0 and x_max > 0:
+            if linthresh <= x_max:
+                breakpoints.add(linthresh)
+
+        breakpoints.add(x_min)
+        breakpoints.add(x_max)
+        breakpoints = sorted(breakpoints)
+
+        # Symlog range for normalization
+        s_min = float(symlog(x_min))
+        s_max = float(symlog(x_max))
         s_range = s_max - s_min
         if s_range == 0:
             return
 
+        # Sample RGB from the linear LUT at symlog-normalized positions
+        rgb = [0.0, 0.0, 0.0]
         new_rgb_points = []
-        for i in range(n_samples):
-            # Uniform position in data space
-            t = i / (n_samples - 1)
-            x_data = x_min + t * data_range
-
-            # Map x_data through symlog, normalize to [0,1], then look up
-            # the color at the corresponding linear position
-            s_val = symlog(x_data)
-            s_t = (s_val - s_min) / s_range
-            x_lookup = x_min + s_t * data_range
+        for v in breakpoints:
+            t = (float(symlog(v)) - s_min) / s_range
+            x_lookup = x_min + t * data_range
             ctf.GetColor(x_lookup, rgb)
             new_rgb_points.extend(
-                [float(x_data), float(rgb[0]), float(rgb[1]), float(rgb[2])]
+                [float(v), float(rgb[0]), float(rgb[1]), float(rgb[2])]
             )
 
-        # Write back through the proxy so state stays in sync
         self.lut.RGBPoints = new_rgb_points
 
     def color_range_str_to_float(self, color_value_min, color_value_max):
@@ -350,26 +365,27 @@ class VariableView(TrameComponent):
             self.config.n_colors,
         )
 
-    def _compute_ticks(self):
+    def _compute_ticks(self, linthresh=None):
         vmin, vmax = self.config.color_range
-        ticks = compute_color_ticks(vmin, vmax, scale=self.config.use_log_scale, n=5)
-        if not ticks:
+        ticks = compute_color_ticks(
+            vmin, vmax, scale=self.config.use_log_scale, n=5, linthresh=linthresh
+        )
+        # Sample colors exactly as lut_to_img does: use RGBPoints range
+        rgb_points = self.lut.RGBPoints
+        if len(rgb_points) < 4:
             self.config.color_ticks = []
             return
-        # The colorbar image is always rendered from the linear LUT, so
-        # sample contrast colors using the linear color_range.
         ctf = self.lut.GetClientSideObject()
         rgb = [0.0, 0.0, 0.0]
-        cr_min, cr_max = float(vmin), float(vmax)
-        cr_range = cr_max - cr_min
-        if cr_range == 0:
+        img_min = rgb_points[0]
+        img_max = rgb_points[-4]
+        img_range = img_max - img_min
+        if img_range == 0:
             self.config.color_ticks = []
             return
         for tick in ticks:
-            # tick position is already in the correct visual space (0-100%)
             t = tick["position"] / 100.0
-            # Map back to the linear data range to sample the color
-            value = cr_min + t * cr_range
+            value = img_min + t * img_range
             ctf.GetColor(value, rgb)
             tick["color"] = tick_contrast_color(rgb[0], rgb[1], rgb[2])
         self.config.color_ticks = ticks
@@ -385,7 +401,6 @@ class VariableView(TrameComponent):
                     "active_layout !== 'auto_layout' ? `height: calc(100% - ${top_padding}px;` : 'overflow-hidden'",
                 ),
                 tile=("active_layout !== 'auto_layout'",),
-                raw_attrs=[f'data-field-name="{self.variable_name}"'],
             ):
                 with v3.VRow(
                     dense=True,
@@ -411,14 +426,6 @@ class VariableView(TrameComponent):
                                         ),
                                     )
 
-                    v3.VIconBtn(
-                        v_tooltip_bottom="'Capture as png'",
-                        icon="mdi-camera-outline",
-                        size="small",
-                        variant="plain",
-                        click=f"utils.quickview.capturePanel('{self.variable_name}')",
-                        style="transform: scale(0.75);",
-                    )
                     v3.VIcon(
                         "mdi-lock-outline",
                         size="x-small",
@@ -479,13 +486,6 @@ class ViewManager(TrameComponent):
         self._camera = vtkCamera(parallel_projection=1)
         self._render_window = vtkRenderWindow()
         self._render_window.OffScreenRenderingOn()
-
-        # Perf: time the actual VTK render on the shared render window.
-        # Emits `view.shared.render_window` with the elapsed time for
-        # each render. See VariableView._on_render_* in view_manager.py.
-        self._render_t0 = None
-        self._render_window.AddObserver("StartEvent", self._on_render_start)
-        self._render_window.AddObserver("EndEvent", self._on_render_end)
         self._style = vtkPVInteractorStyle()
         self._style.AddManipulator(
             vtkPVTrackballZoom(
@@ -537,16 +537,6 @@ class ViewManager(TrameComponent):
         # Sort lists
         self.state.luts_normal.sort(key=lut_name)
         self.state.luts_inverted.sort(key=lut_name)
-
-    def _on_render_start(self, *_):
-        if perf.is_enabled():
-            self._render_t0 = time.perf_counter()
-
-    def _on_render_end(self, *_):
-        if perf.is_enabled() and self._render_t0 is not None:
-            dt_ms = (time.perf_counter() - self._render_t0) * 1000.0
-            perf.log("view.shared.render_window", dt_ms)
-            self._render_t0 = None
 
     def refresh_ui(self, **_):
         for view in self._var2view.values():
@@ -729,7 +719,6 @@ class ViewManager(TrameComponent):
         # Build a lookup from type name to color from state.variable_types
         type_to_color = {vt["name"]: vt["color"] for vt in self.state.variable_types}
         with DivLayout(self.server, template_name="auto_layout") as self.ui:
-            self.ui.root.classes = "all-variables"
             if self.state.layout_grouped:
                 with v3.VCol(classes="pa-1"):
                     for var_type in variables.keys():


### PR DESCRIPTION
- Compute linthresh from min abs non-zero value in data array (zero-copy, vectorized O(n))
- Fix symlog function to standard formulation: sign(v) * log10(1 + |v|/linthresh)
- Fix log/symlog tick positions to use normalized positions on linear colorbar
- Fix symlog tick values to use powers of 10 matching LUT breakpoints
- Capture linear colorbar image before any log/symlog LUT transforms
- Pass linthresh once from data through all functions that need it