### PR TITLE
Fix linthresh: use dtype tiny instead of sqrt(eps) as zero threshold

### DIFF
--- a/src/e3sm_quickview/utils/math.py
+++ b/src/e3sm_quickview/utils/math.py
@@ -12,7 +12,7 @@ from typing import List, Tuple, Optional
 def calculate_linthresh(data):
     """Calculate the linear threshold for symlog scaling.
 
-    Excludes machine-error zeros (values within ±sqrt(eps) of the data dtype),
+    Excludes true zeros (values within ±tiny of the data dtype),
     then returns min(abs(valid)).
 
     Operates on the original array without copies.
@@ -21,10 +21,9 @@ def calculate_linthresh(data):
         data: numpy array of data values
 
     Returns:
-        linthresh value (float), clamped to at least 1.0
+        linthresh value (float), floored at dtype tiny to avoid zero
     """
-    eps = np.finfo(data.dtype).eps
-    threshold = np.sqrt(eps)
+    threshold = np.finfo(data.dtype).tiny
 
     # Find min |x| > threshold without allocating a copy.
     # Using where= runs as a tight vectorized C loop, roughly 2-3 orders
@@ -37,7 +36,7 @@ def calculate_linthresh(data):
     if min_abs == np.inf:
         linthresh = 1.0
     else:
-        linthresh = max(float(min_abs), 1.0)
+        linthresh = max(float(min_abs), float(np.finfo(data.dtype).tiny))
 
     return linthresh
 


### PR DESCRIPTION
<img width="1522" height="581" alt="Screenshot 2026-04-28 at 8 49 33 AM" src="https://github.com/user-attachments/assets/8d39280c-b58e-4c87-9372-f5ea21ebfe33" />

Fix symlog colormap appearing linear for small-magnitude data

calculate_linthresh used sqrt(eps) (~1.5e-8 for float64) as the zero-exclusion threshold, which filtered out legitimately small data values (e.g. aerosol concentrations at 1e-13), causing the fallback linthresh = 1.0. This made the symlog transform collapse to near-zero spread.

Changed to use dtype.tiny (~2.2e-308) and removed the max(..., 1.0) clamp so linthresh reflects the actual smallest positive magnitude in the data.

closes #62 