### PR TITLE
Fix symlog colorbar matching and discrete sampling

### DIFF
--- a/src/e3sm_quickview/components/view.py
+++ b/src/e3sm_quickview/components/view.py
@@ -227,12 +227,12 @@ def create_bottom_bar(config, update_color_preset):
                             variant="outlined",
                             flat=True,
                             label=(
-                                "config.use_log_scale === 'linear' ? 'Colors per tick interval' : 'Colors per decade'",
+                                "config.use_log_scale === 'linear' ? 'Colors per tick interval' : 'Colors per order of magnitude'",
                             ),
                             classes="mt-2",
                             step=[1],
                             min=[1],
-                            max=[5],
+                            max=[20],
                         )
                     with v3.VCardItem(
                         v_show="config.override_range", classes="py-0 mb-2"

--- a/src/e3sm_quickview/utils/math.py
+++ b/src/e3sm_quickview/utils/math.py
@@ -233,8 +233,6 @@ def get_nice_ticks(vmin, vmax, n, scale="linear", linthresh=None):
                     ticks_set.add(val)
         if vmin <= 0 <= vmax:
             ticks_set.add(0.0)
-        ticks_set.add(vmin)
-        ticks_set.add(vmax)
         raw_ticks = np.array(sorted(ticks_set))
         # Skip snap — powers of 10 are already nice
         return raw_ticks
@@ -258,7 +256,7 @@ def format_tick(val):
     shown as '10^N', very large/small values use scientific notation, and
     intermediate values use fixed-point.
     """
-    if np.isclose(val, 0, atol=1e-12):
+    if val == 0:
         return "0"
 
     val_abs = abs(val)
@@ -354,7 +352,7 @@ def compute_color_ticks(
         else:
             pos = (val - vmin) / data_range * 100
         if edge_margin <= pos <= (100 - edge_margin):
-            is_zero = np.isclose(val, 0, atol=1e-12)
+            is_zero = val == 0
             if is_zero:
                 has_zero = True
             candidates.append(

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -226,7 +226,7 @@ class VariableView(TrameComponent):
             else:
                 linthresh = 1.0
 
-        n_sub = max(1, min(5, int(n_discrete_colors)))
+        n_sub = max(1, min(20, int(n_discrete_colors)))
         if log_scale == "linear" and discrete_log:
             display_rgb_points = self._apply_discrete_linear_to_lut(
                 linear_rgb_points, n_sub
@@ -560,18 +560,24 @@ class VariableView(TrameComponent):
         # Sample RGB from the linear CTF at symlog-normalized positions
         rgb = [0.0, 0.0, 0.0]
         new_rgb_points = []
+        display_rgb_points = []
         for v in breakpoints:
             t = (float(symlog(v)) - s_min) / s_range
             x_lookup = x_min + t * data_range
             linear_ctf.GetColor(x_lookup, rgb)
-            new_rgb_points.extend(
-                [float(v), float(rgb[0]), float(rgb[1]), float(rgb[2])]
-            )
+            r, g, b = float(rgb[0]), float(rgb[1]), float(rgb[2])
+            new_rgb_points.extend([float(v), r, g, b])
+            # Display points: uniform linear positions with symlog colors
+            display_rgb_points.extend([x_lookup, r, g, b])
 
-        # Store on proxy for bookkeeping — the actual CTF used by the
+        # Regenerate colorbar image from display points so it matches the 3D
+        self.lut.UseLogScale = 0
+        self.lut.RGBPoints = display_rgb_points
+        self.config.lut_img = lut_to_img(self.lut)
+
+        # Store rendering points on proxy — the actual CTF used by the
         # mapper is a standalone vtkColorTransferFunction built in
         # update_color_preset to avoid proxy client-side object issues.
-        self.lut.UseLogScale = 0
         self.lut.RGBPoints = new_rgb_points
 
     def _apply_discrete_symlog_to_lut(self, linthresh, linear_rgb_points, n_sub=1):
@@ -666,7 +672,8 @@ class VariableView(TrameComponent):
         else:
             self._discrete_tick_data = all_tick_data
 
-        # Build a temporary linear CTF from the saved linear RGB points
+        # Build a continuous symlog CTF (same as _apply_symlog_to_lut) so
+        # discrete bands sample colours that match the continuous rendering.
         from vtkmodules.vtkRenderingCore import vtkColorTransferFunction
 
         linear_ctf = vtkColorTransferFunction()
@@ -678,12 +685,24 @@ class VariableView(TrameComponent):
                 linear_rgb_points[i + 3],
             )
 
+        n_samples = 256
+        s_vals = np.linspace(s_min, s_max, n_samples)
+        symlog_ctf = vtkColorTransferFunction()
+        rgb_tmp = [0.0, 0.0, 0.0]
+        for s in s_vals:
+            v = float(np.sign(s) * linthresh * (10.0 ** abs(s) - 1.0))
+            v = max(x_min, min(x_max, v))
+            t = (s - s_min) / s_range
+            x_lookup = x_min + t * data_range
+            linear_ctf.GetColor(x_lookup, rgb_tmp)
+            symlog_ctf.AddRGBPoint(v, rgb_tmp[0], rgb_tmp[1], rgb_tmp[2])
+
         # For each decade interval, split into n_sub equal sub-bands in
         # symlog space.  Each sub-band gets a flat color sampled from the
-        # continuous LUT at the sub-band midpoint.
+        # continuous symlog LUT at the sub-band midpoint.
         rgb = [0.0, 0.0, 0.0]
         eps_data = (x_max - x_min) * 1e-9
-        eps_lin = 1e-9
+        eps_lin = data_range * 1e-9
         display_rgb_points = []
         render_rgb_points = []
         band_idx = 0
@@ -696,9 +715,11 @@ class VariableView(TrameComponent):
                 s_lo = s_lo_decade + (s_hi_decade - s_lo_decade) * j / n_sub
                 s_hi = s_lo_decade + (s_hi_decade - s_lo_decade) * (j + 1) / n_sub
                 s_mid = (s_lo + s_hi) / 2.0
-                t_mid = (s_mid - s_min) / s_range
-                x_lookup = x_min + t_mid * data_range
-                linear_ctf.GetColor(x_lookup, rgb)
+
+                # Invert symlog to get data-space values
+                v_mid = float(np.sign(s_mid) * linthresh * (10.0 ** abs(s_mid) - 1.0))
+                v_mid = max(x_min, min(x_max, v_mid))
+                symlog_ctf.GetColor(v_mid, rgb)
                 r, g, b = float(rgb[0]), float(rgb[1]), float(rgb[2])
 
                 # Invert symlog to get data-space boundaries for rendering

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -223,7 +223,7 @@ class VariableView(TrameComponent):
             else:
                 linthresh = 1.0
 
-        n_sub = max(1, min(5, int(n_discrete_colors)))
+        n_sub = max(1, min(20, int(n_discrete_colors)))
         if log_scale == "linear" and discrete_log:
             display_rgb_points = self._apply_discrete_linear_to_lut(
                 linear_rgb_points, n_sub
@@ -560,18 +560,24 @@ class VariableView(TrameComponent):
         # Sample RGB from the linear CTF at symlog-normalized positions
         rgb = [0.0, 0.0, 0.0]
         new_rgb_points = []
+        display_rgb_points = []
         for v in breakpoints:
             t = (float(symlog(v)) - s_min) / s_range
             x_lookup = x_min + t * data_range
             linear_ctf.GetColor(x_lookup, rgb)
-            new_rgb_points.extend(
-                [float(v), float(rgb[0]), float(rgb[1]), float(rgb[2])]
-            )
+            r, g, b = float(rgb[0]), float(rgb[1]), float(rgb[2])
+            new_rgb_points.extend([float(v), r, g, b])
+            # Display points: uniform linear positions with symlog colors
+            display_rgb_points.extend([x_lookup, r, g, b])
 
-        # Store on proxy for bookkeeping — the actual CTF used by the
+        # Regenerate colorbar image from display points so it matches the 3D
+        self.lut.UseLogScale = 0
+        self.lut.RGBPoints = display_rgb_points
+        self.config.lut_img = lut_to_img(self.lut)
+
+        # Store rendering points on proxy — the actual CTF used by the
         # mapper is a standalone vtkColorTransferFunction built in
         # update_color_preset to avoid proxy client-side object issues.
-        self.lut.UseLogScale = 0
         self.lut.RGBPoints = new_rgb_points
 
     def _apply_discrete_symlog_to_lut(self, linthresh, linear_rgb_points, n_sub=1):
@@ -666,7 +672,8 @@ class VariableView(TrameComponent):
         else:
             self._discrete_tick_data = all_tick_data
 
-        # Build a temporary linear CTF from the saved linear RGB points
+        # Build a continuous symlog CTF (same as _apply_symlog_to_lut) so
+        # discrete bands sample colours that match the continuous rendering.
         from vtkmodules.vtkRenderingCore import vtkColorTransferFunction
 
         linear_ctf = vtkColorTransferFunction()
@@ -678,12 +685,24 @@ class VariableView(TrameComponent):
                 linear_rgb_points[i + 3],
             )
 
+        n_samples = 256
+        s_vals = np.linspace(s_min, s_max, n_samples)
+        symlog_ctf = vtkColorTransferFunction()
+        rgb_tmp = [0.0, 0.0, 0.0]
+        for s in s_vals:
+            v = float(np.sign(s) * linthresh * (10.0 ** abs(s) - 1.0))
+            v = max(x_min, min(x_max, v))
+            t = (s - s_min) / s_range
+            x_lookup = x_min + t * data_range
+            linear_ctf.GetColor(x_lookup, rgb_tmp)
+            symlog_ctf.AddRGBPoint(v, rgb_tmp[0], rgb_tmp[1], rgb_tmp[2])
+
         # For each decade interval, split into n_sub equal sub-bands in
         # symlog space.  Each sub-band gets a flat color sampled from the
-        # continuous LUT at the sub-band midpoint.
+        # continuous symlog LUT at the sub-band midpoint.
         rgb = [0.0, 0.0, 0.0]
         eps_data = (x_max - x_min) * 1e-9
-        eps_lin = 1e-9
+        eps_lin = data_range * 1e-9
         display_rgb_points = []
         render_rgb_points = []
         band_idx = 0
@@ -696,9 +715,11 @@ class VariableView(TrameComponent):
                 s_lo = s_lo_decade + (s_hi_decade - s_lo_decade) * j / n_sub
                 s_hi = s_lo_decade + (s_hi_decade - s_lo_decade) * (j + 1) / n_sub
                 s_mid = (s_lo + s_hi) / 2.0
-                t_mid = (s_mid - s_min) / s_range
-                x_lookup = x_min + t_mid * data_range
-                linear_ctf.GetColor(x_lookup, rgb)
+
+                # Invert symlog to get data-space values
+                v_mid = float(np.sign(s_mid) * linthresh * (10.0 ** abs(s_mid) - 1.0))
+                v_mid = max(x_min, min(x_max, v_mid))
+                symlog_ctf.GetColor(v_mid, rgb)
                 r, g, b = float(rgb[0]), float(rgb[1]), float(rgb[2])
 
                 # Invert symlog to get data-space boundaries for rendering


### PR DESCRIPTION
Fix symlog colorbar and discrete color sampling

- Regenerate colorbar image after symlog remap so it matches the 3D rendering (previously captured from the linear LUT before remap, causing color mismatch)
- Sample discrete symlog band colors from a continuous symlog CTF instead of the linear CTF, so discrete colors stay consistent with continuous mode as subdivisions increase
- Use exact val == 0 in format_tick and tick detection instead of np.isclose(atol=1e-12), which was labeling small values like 1.38e-13 as "0" and producing duplicate zero ticks
- Remove vmin/vmax from symlog interior tick set to avoid extra edge ticks
- Rename "Colors per decade" to "Colors per order of magnitude"
- Increase max color subdivisions from 5 to 20
- Make eps_lin relative to data_range to prevent band overlap with small-valued data

closes #65 
closes #64