### PR TITLE
Fix aspect ratio slider: invert direction, allow shorter views

### DIFF
--- a/src/e3sm_quickview/components/toolbars.py
+++ b/src/e3sm_quickview/components/toolbars.py
@@ -47,11 +47,11 @@ class Layout(v3.VToolbar):
             v3.VSpacer()
 
             v3.VSlider(
-                v_model=("aspect_ratio", 2),
-                prepend_icon="mdi-arrow-expand-horizontal",
-                min=1,
+                v_model=("aspect_ratio", 0.5),
+                prepend_icon="mdi-arrow-expand-vertical",
+                min=0.25,
                 max=2,
-                step=0.1,
+                step=0.05,
                 density="compact",
                 hide_details=True,
                 style="max-width: 400px;",

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -956,7 +956,7 @@ class VariableView(TrameComponent):
                     style=(
                         """
                         {
-                            aspectRatio: active_layout === 'auto_layout' ? aspect_ratio : null,
+                            aspectRatio: active_layout === 'auto_layout' ? (1.0 / aspect_ratio) : null,
                             height: active_layout !== 'auto_layout' ? 'calc(100% - 2.4rem)' : null,
                             pointerEvents: lock_views ? 'none': null,
                         }

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -955,7 +955,7 @@ class VariableView(TrameComponent):
                     style=(
                         """
                         {
-                            aspectRatio: active_layout === 'auto_layout' ? aspect_ratio : null,
+                            aspectRatio: active_layout === 'auto_layout' ? (1.0 / aspect_ratio) : null,
                             height: active_layout !== 'auto_layout' ? 'calc(100% - 2.4rem)' : null,
                             pointerEvents: lock_views ? 'none': null,
                         }


### PR DESCRIPTION
Fix aspect ratio slider: invert direction, allow shorter views

- Invert slider so sliding right = taller view (smaller width-to-height ratio)
- Change icon from mdi-arrow-expand-horizontal to mdi-arrow-expand-vertical
- Expand range from [1, 2] to [0.25, 2], allowing much shorter/wider views (up to 4:1 w/h ratio) for tropical-focused plots
- Default 0.5 gives a 2:1 width-to-height ratio
 
Default

<img width="1516" height="877" alt="ar-default" src="https://github.com/user-attachments/assets/578b7b5e-47df-4e2b-bd16-480d586a7d22" />

Shorter

<img width="1536" height="885" alt="ar-shorter" src="https://github.com/user-attachments/assets/04cc8b24-353f-4f06-8521-80262d7ce6d5" />

Taller

 
<img width="1562" height="884" alt="ar-taller" src="https://github.com/user-attachments/assets/2fada68f-35bf-4ce0-9ab9-36a1a4e3feff" />

Note: This is a breaking change for previous saved state files. Simplest Fix: Just let it load as-is. If someone loads an old state file with aspect_ratio: 2, under the new scheme that means very tall (CSS ratio 0.5). Previously it meant very wide (CSS ratio 2). The visual will differ, but the they can just adjust the slider. I feel this is acceptable for a layout preference. True Fix: The ranges overlap at [1, 2], so there's no way to distinguish an old state value of 1.5  from a new state value of 1.5. The only clean fix would be renaming the state variable (e.g. view_height_ratio) or adding a version field to the state file, which I thought would be over engineering compared to adjusting one slider.

closes #61