### PR TITLE
Fix state file save/restore: dynamic dimension indices, discrete/colo…

### DIFF
--- a/src/e3sm_quickview/app.py
+++ b/src/e3sm_quickview/app.py
@@ -306,17 +306,20 @@ class EAMApp(TrameApp):
             "tools": self.state.active_tools,
             "help": not self.state.compact_drawer,
         }
-        state_content["data-selection"] = {
+        data_selection = {
             k: self.state[k]
             for k in [
-                "time_idx",
-                "midpoint_idx",
-                "interface_idx",
                 "crop_longitude",
                 "crop_latitude",
                 "projection",
             ]
         }
+        # Save all dynamic dimension indices
+        for dim_name in getattr(self.state, "available_animation_tracks", None) or []:
+            idx_key = f"{dim_name}_idx"
+            data_selection[idx_key] = getattr(self.state, idx_key, 0)
+        data_selection["animation_track"] = self.state.animation_track
+        state_content["data-selection"] = data_selection
         views_to_export = state_content["views"] = []
         for view_type, var_names in active_variables.items():
             for var_name in var_names:
@@ -329,7 +332,10 @@ class EAMApp(TrameApp):
                             # lut
                             "preset": config.preset,
                             "invert": config.invert,
+                            "color_blind": config.color_blind,
                             "use_log_scale": config.use_log_scale,
+                            "discrete_log": config.discrete_log,
+                            "n_discrete_colors": config.n_discrete_colors,
                             # layout
                             "order": config.order,
                             "size": config.size,
@@ -370,16 +376,34 @@ class EAMApp(TrameApp):
 
         # Load variables
         self.state.variables_selected = state_content["variables-selection"]
-        self.state.update(state_content["data-selection"])
+        # Apply non-index data-selection fields (crop, projection) before load
+        data_sel = state_content["data-selection"]
+        non_idx = {
+            k: v
+            for k, v in data_sel.items()
+            if not k.endswith("_idx") and k != "animation_track"
+        }
+        self.state.update(non_idx)
         await self._data_load_variables()
         self.state.variables_loaded = True
+
+        # Restore dimension indices after data is loaded
+        with self.state:
+            for k, v in data_sel.items():
+                if k.endswith("_idx"):
+                    self.state[k] = v
+            if "animation_track" in data_sel:
+                self.state.animation_track = data_sel["animation_track"]
 
         # Update view states
         for view_state in state_content["views"]:
             view_type = view_state["type"]
             var_name = view_state["name"]
+            cfg = view_state["config"]
+            if "color_range" in cfg and isinstance(cfg["color_range"], list):
+                cfg["color_range"] = tuple(cfg["color_range"])
             config = self.view_manager.get_view(var_name, view_type).config
-            config.update(**view_state["config"])
+            config.update(**cfg)
 
         # Update layout
         self.state.aspect_ratio = state_content["layout"]["aspect-ratio"]


### PR DESCRIPTION
Fix state file save/restore

- Save all dynamic dimension indices (lev_idx, cosp_sr_idx, etc.) instead of hardcoded time_idx/midpoint_idx/interface_idx
- Restore dimension indices after data load so dynamic state variables exist
- Save/restore animation_track selection
- Add color_blind, discrete_log, n_discrete_colors to per-view config export
- Convert color_range from list to tuple on import to avoid trame_dataclass validation warnings

Note: when we add new features we need to check that we are saving/restoring all the state in app.py (Save: download_state method) and (Restore: _import_state method). If you add a new global state variable, add it to whichever section it belongs to (layout, data-selection) in both save and restore. Also, look for JSON type mismatches (lists vs tuples).

New state saved

[quickview-state-new.json](https://github.com/user-attachments/files/27206115/quickview-state-new.json)

Loaded from saved state

<img width="1522" height="876" alt="Screenshot 2026-04-29 at 9 39 20 AM" src="https://github.com/user-attachments/assets/29e8ae0a-0887-497b-8fd6-f16d09f52fa3" />

closes #66
