### PR TITLE
fix: disable view interaction and add zoom buttons to layout toolbar

### DIFF
--- a/src/e3sm_quickview/app.py
+++ b/src/e3sm_quickview/app.py
@@ -167,7 +167,6 @@ class EAMApp(TrameApp):
                 ProjectionEquidistant="projection = ['Cyl. Equidistant']",
                 ProjectionRobinson="projection = ['Robinson']",
                 ProjectionMollweide="projection = ['Mollweide']",
-                ToggleViewLock="lock_views = !lock_views",
                 FileOpen=(self.toggle_toolbar, "['load-data']"),
                 SaveState="trigger('download_state_dialog')",
                 UploadState="utils.get('document').querySelector('#fileUpload').click()",
@@ -199,8 +198,6 @@ class EAMApp(TrameApp):
 
                 mt.bind("v", "ToggleVariableSelection")
 
-                mt.bind("space", "ToggleViewLock", stop_propagation=True)
-
                 mt.bind("esc", "RemoveAllToolbars")
 
             # Native Dialogs
@@ -225,7 +222,11 @@ class EAMApp(TrameApp):
 
                             # Fixed overlay for toolbars
                             with html.Div(style=css.TOOLBARS_FIXED_OVERLAY):
-                                toolbars.Layout(apply_size=self.view_manager.apply_size)
+                                toolbars.Layout(
+                                    apply_size=self.view_manager.apply_size,
+                                    zoom_in=self.view_manager.zoom_in,
+                                    zoom_out=self.view_manager.zoom_out,
+                                )
                                 toolbars.Cropping()
                                 toolbars.DataSelection()
                                 toolbars.Animation()
@@ -306,6 +307,7 @@ class EAMApp(TrameApp):
             "active": self.state.active_layout,
             "tools": self.state.active_tools,
             "help": not self.state.compact_drawer,
+            "zoom": self.view_manager.get_zoom(),
         }
         data_selection = {
             k: self.state[k]
@@ -413,6 +415,8 @@ class EAMApp(TrameApp):
         self.state.active_layout = state_content["layout"]["active"]
         self.state.active_tools = state_content["layout"]["tools"]
         self.state.compact_drawer = not state_content["layout"]["help"]
+        if "zoom" in state_content["layout"]:
+            self.view_manager.set_zoom(state_content["layout"]["zoom"])
 
         # Update filebrowser state
         with self.state:

--- a/src/e3sm_quickview/components/toolbars.py
+++ b/src/e3sm_quickview/components/toolbars.py
@@ -38,13 +38,26 @@ def to_kwargs(value):
 
 
 class Layout(v3.VToolbar):
-    def __init__(self, apply_size=None):
+    def __init__(self, apply_size=None, zoom_in=None, zoom_out=None):
         super().__init__(**to_kwargs("adjust-layout"))
 
         with self:
             v3.VIcon("mdi-view-module", classes="px-6 opacity-50")
             v3.VLabel("Viewport layout", classes="text-subtitle-2")
             v3.VSpacer()
+
+            v3.VIconBtn(
+                v_tooltip_bottom="'Zoom in'",
+                icon="mdi-magnify-plus-outline",
+                flat=True,
+                click=zoom_in,
+            )
+            v3.VIconBtn(
+                v_tooltip_bottom="'Zoom out'",
+                icon="mdi-magnify-minus-outline",
+                flat=True,
+                click=zoom_out,
+            )
 
             v3.VSlider(
                 v_model=("aspect_ratio", 0.5),
@@ -457,24 +470,28 @@ class Animation(v3.VToolbar):
                 )
                 v3.VDivider(vertical=True, classes="mx-2")
                 v3.VIconBtn(
+                    v_tooltip_bottom="'First step'",
                     icon="mdi-page-first",
                     flat=True,
                     disabled=("animation_step === 0",),
                     click="animation_step = 0",
                 )
                 v3.VIconBtn(
+                    v_tooltip_bottom="'Previous step'",
                     icon="mdi-chevron-left",
                     flat=True,
                     disabled=("animation_step === 0",),
                     click="animation_step = Math.max(0, animation_step - 1)",
                 )
                 v3.VIconBtn(
+                    v_tooltip_bottom="'Next step'",
                     icon="mdi-chevron-right",
                     flat=True,
                     disabled=("animation_step === animation_step_max",),
                     click="animation_step = Math.min(animation_step_max, animation_step + 1)",
                 )
                 v3.VIconBtn(
+                    v_tooltip_bottom="'Last step'",
                     icon="mdi-page-last",
                     disabled=("animation_step === animation_step_max",),
                     flat=True,
@@ -482,6 +499,7 @@ class Animation(v3.VToolbar):
                 )
                 v3.VDivider(vertical=True, classes="mx-2")
                 v3.VIconBtn(
+                    v_tooltip_bottom="'Play reverse'",
                     icon=(
                         "animation_play && animation_direction === 'reverse' ? 'mdi-stop' : 'mdi-play'",
                     ),
@@ -493,6 +511,7 @@ class Animation(v3.VToolbar):
                     style="transform: scaleX(-1);",
                 )
                 v3.VIconBtn(
+                    v_tooltip_bottom="'Play forward'",
                     icon=(
                         "animation_play && animation_direction === 'forward' ? 'mdi-stop' : 'mdi-play'",
                     ),

--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -912,13 +912,6 @@ class VariableView(TrameComponent):
                                         ),
                                     )
 
-                    v3.VIcon(
-                        "mdi-lock-outline",
-                        size="x-small",
-                        v_show=("lock_views", True),
-                        style="transform: scale(0.75);",
-                    )
-
                     v3.VSpacer()
                     html.Div(
                         "t = {{ time_idx }}",
@@ -958,7 +951,7 @@ class VariableView(TrameComponent):
                         {
                             aspectRatio: active_layout === 'auto_layout' ? (1.0 / aspect_ratio) : null,
                             height: active_layout !== 'auto_layout' ? 'calc(100% - 2.4rem)' : null,
-                            pointerEvents: lock_views ? 'none': null,
+                            pointerEvents: 'none',
                         }
                         """,
                     ),
@@ -1012,6 +1005,30 @@ class ViewManager(TrameComponent):
 
         for view in views:
             view.disable_render = False
+
+    def zoom_in(self):
+        for view in list(self._var2view.values()):
+            cam = view.camera
+            cam.SetParallelScale(cam.GetParallelScale() / 1.2)
+            view.render()
+
+    def zoom_out(self):
+        for view in list(self._var2view.values()):
+            cam = view.camera
+            cam.SetParallelScale(cam.GetParallelScale() * 1.2)
+            view.render()
+
+    def get_zoom(self):
+        for view in list(self._var2view.values()):
+            return view.camera.GetParallelScale()
+        return None
+
+    def set_zoom(self, scale):
+        if scale is None:
+            return
+        for view in list(self._var2view.values()):
+            view.camera.SetParallelScale(scale)
+            view.render()
 
     def render(self):
         for view in list(self._var2view.values()):

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -918,12 +918,6 @@ class VariableView(TrameComponent):
                         click=f"utils.quickview.capturePanel('{self.variable_name}')",
                         style="transform: scale(0.75);",
                     )
-                    v3.VIcon(
-                        "mdi-lock-outline",
-                        size="x-small",
-                        v_show=("lock_views", True),
-                        style="transform: scale(0.75);",
-                    )
 
                     v3.VSpacer()
                     html.Div(
@@ -957,13 +951,13 @@ class VariableView(TrameComponent):
                         {
                             aspectRatio: active_layout === 'auto_layout' ? (1.0 / aspect_ratio) : null,
                             height: active_layout !== 'auto_layout' ? 'calc(100% - 2.4rem)' : null,
-                            pointerEvents: lock_views ? 'none': null,
+                            pointerEvents: 'none',
                         }
                         """,
                     ),
                 ):
                     rca.ImageRegion(
-                        enable_interaction=True,
+                        enable_interaction=False,
                         bounds=(self._bounds_key, (0, 0, 1, 1)),
                         size=(self.update_size, "[$event]"),
                     )
@@ -1082,6 +1076,25 @@ class ViewManager(TrameComponent):
 
         if render and view_to_reset:
             self.render()
+
+    def zoom_in(self):
+        scale = self._camera.GetParallelScale()
+        self._camera.SetParallelScale(scale / 1.2)
+        self.render()
+
+    def zoom_out(self):
+        scale = self._camera.GetParallelScale()
+        self._camera.SetParallelScale(scale * 1.2)
+        self.render()
+
+    def get_zoom(self):
+        return self._camera.GetParallelScale()
+
+    def set_zoom(self, scale):
+        if scale is None:
+            return
+        self._camera.SetParallelScale(scale)
+        self.render()
 
     @controller.set("size_update")
     def on_size_update(self):


### PR DESCRIPTION
Disable view interaction, add zoom buttons to layout toolbar

Replace direct mouse-based view interaction with explicit zoom controls on the viewport layout toolbar.

- Remove lock icon and space-key shortcut for toggling view lock
- Disable pointer events and interaction on all view panels
- Add zoom-in/zoom-out buttons (magnify icons) to viewport layout toolbar
- Save/restore zoom level (camera ParallelScale) in state file
- Add get_zoom/set_zoom/zoom_in/zoom_out to both ViewManagers
- Add tooltips to all animation toolbar buttons"

Viewport Layout Toolbar

<img width="1523" height="878" alt="zoom" src="https://github.com/user-attachments/assets/8df6a64e-2564-40d1-a0ee-d79dcb6cd395" />

closes #80 