### PR TITLE
fix: use showSaveFilePicker for state export with browser fallback

### DIFF
--- a/src/e3sm_quickview/components/dialogs.py
+++ b/src/e3sm_quickview/components/dialogs.py
@@ -23,7 +23,7 @@ class StateDownload(html.Div):
                 model_value=("show_export_dialog", False),
                 **css.DIALOG_STYLES,
             ):
-                with v3.VCard(title="Download QuickView State file", rounded="lg"):
+                with v3.VCard(title="Save QuickView State file", rounded="lg"):
                     v3.VDivider()
                     with v3.VCardText():
                         with v3.VRow(dense=True):
@@ -38,7 +38,9 @@ class StateDownload(html.Div):
                                         "quickview-state.json",
                                     ),
                                     density="comfortable",
-                                    placeholder="Enter the filename to download",
+                                    placeholder="Enter a filename (not a path)",
+                                    hint="Name only — save location is chosen via dialog or defaults to ~/Downloads",
+                                    persistent_hint=True,
                                     variant="outlined",
                                 )
                         with v3.VRow(dense=True):
@@ -64,9 +66,35 @@ class StateDownload(html.Div):
                             color="surface",
                         )
                         v3.VBtn(
-                            text="Download",
+                            text="Save",
                             classes="text-none",
                             variant="flat",
                             color="primary",
-                            click="show_export_dialog=false;utils.download(download_name, trigger('download_state'), 'application/json')",
+                            click="""
+                                show_export_dialog=false;
+                                const fname = download_name.split('/').pop() || 'quickview-state.json';
+                                if (window.showSaveFilePicker) {
+                                    (async () => {
+                                        try {
+                                            const content = await trigger('download_state');
+                                            const handle = await window.showSaveFilePicker({
+                                                suggestedName: fname,
+                                                types: [{
+                                                    description: 'JSON State File',
+                                                    accept: {'application/json': ['.json']},
+                                                }],
+                                            });
+                                            const writable = await handle.createWritable();
+                                            await writable.write({type: 'write', data: content});
+                                            await writable.close();
+                                        } catch(e) {
+                                            if (e.name !== 'AbortError') console.error(e);
+                                        }
+                                    })();
+                                } else {
+                                    trigger('download_state').then((content) => {
+                                        utils.download(fname, content, 'application/json');
+                                    });
+                                }
+                            """,
                         )

--- a/src/e3sm_quickview/components/tools.py
+++ b/src/e3sm_quickview/components/tools.py
@@ -287,9 +287,7 @@ class StateImportExport(v3.VTooltip):
                     ):
                         with v3.VList(density="compact"):
                             v3.VListItem(
-                                title=(
-                                    "is_tauri ? 'Save state file' : 'Download state file'",
-                                ),
+                                title="Save state file",
                                 prepend_icon="mdi-file-download-outline",
                                 click=self.download_state_dialog,
                                 disabled=("!variables_loaded",),


### PR DESCRIPTION
Improve state file export to use the native save-as dialog when available in the browser.

**Note**: This fix does not allow for the user to enter a path instead of just a filename. browser technology has file system access restrictions. We still ask for just a filename here. So, there are are three cases:
- Tauri - Enter a filename and description, then Tauri presents a dialog is presented for selecting the save location.
- Modern Browser (Chrome/Edge with HTTPS or localhost) - Enter a filename and description, then 'showSaveFilePicker' presents a dialog is presented for selecting the save location.
- Browser (Not Modern [Firefox/Safari] or remote HTTP) - Enter a filename and description, then the browser saves to ~/Downloads only.

What we changed:
- Rename "Download" to "Save" throughout the state export UI (dialog title, button, menu item)
- showSaveFilePicker API (Chrome/Edge on secure contexts) — users get a native save-as dialog to choose location
- Fallback to utils.download for Firefox/Safari or non-secure contexts — saves to ~/Downloads
- Filename hint added: "Name only — save location is chosen via dialog or defaults to ~/Downloads"
- Menu item simplified: always says "Save state file" (no longer conditional on Tauri)

Fallback chain:
- Tauri → native OS save dialog (unchanged)
- Browser (Chrome/Edge, localhost/HTTPS) → showSaveFilePicker
- Browser (Firefox/Safari or remote HTTP) → utils.download to ~/Downloads

Remote host access:
The showSaveFilePicker API requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). When accessing QuickView remotely over plain http://, the native save dialog will not be available and the fallback browser download is used instead. To enable the full save-as experience for remote users:

- SSH tunnel — ssh -L 8080:localhost:8080 remote-host — browser sees localhost, secure context satisfied
- CapRover — auto-provisions HTTPS/WSS [trame cloud docs](https://kitware.github.io/trame/guide/deployment/cloud.html)

closes #78