### PR TITLE
fix: allow pasting file paths in file loading dialog

### DIFF
--- a/src/e3sm_quickview/components/file_browser.py
+++ b/src/e3sm_quickview/components/file_browser.py
@@ -375,7 +375,7 @@ class ParaViewFileBrowser(TrameComponent):
                     v_model=(self.name("data_simulation"), ""),
                     density="compact",
                     variant="outlined",
-                    disabled=True,
+                    placeholder="Paste or browse for simulation file path",
                     messages="EAM's history output on the physics grids (pg2 grids) written by EAMv2, v3, and an intermediate version towards v4 (EAMxx).",
                 )
                 html.Label(
@@ -386,7 +386,7 @@ class ParaViewFileBrowser(TrameComponent):
                     v_model=(self.name("data_connectivity"), ""),
                     density="compact",
                     variant="outlined",
-                    disabled=True,
+                    placeholder="Paste or browse for connectivity file path",
                     messages="The horizontal grids used by EAM are cubed spheres. Since these are unstructed grids, QuickView needs to know how to map data to the globe. Therefore, for each simulation data file, a 'connectivity file' needs to be provided.",
                 )
 


### PR DESCRIPTION
Enable pasting file paths directly into the simulation and connectivity text fields in the file loading dialog.

- Removed disabled=True from both the Simulation File and Connectivity File text fields
- Added placeholder text: "Paste or browse for simulation/connectivity file path"

Users can now paste a full file path instead of navigating the file browser tree.

**Note**: Probably needs more error handling
- Selecting via the dialog seamlessly handles path errors, but connectivity/simulation mismatches are not handled.
- Pasting path-filenames there is no seamless error handling for paths or connectivity/simulation mismatches.

closes #77