### PR TITLE
fix: add Enter key to trigger active primary buttons

### DIFF
--- a/src/e3sm_quickview/app.py
+++ b/src/e3sm_quickview/app.py
@@ -525,6 +525,20 @@ class EAMApp(TrameApp):
             tool for tool in self.state.active_tools if tool != "load-data"
         ]
 
+    @trigger("enter_load_files")
+    def _enter_load_files(self):
+        """Route Enter key to load files or import state in the file dialog."""
+        s = self.state
+        if s[self.file_browser.name("is_state_file")]:
+            self.file_browser.import_state_file()
+        elif (
+            s[self.file_browser.name("data_simulation")]
+            and s[self.file_browser.name("data_connectivity")]
+            and not s[self.file_browser.name("error")]
+        ):
+            self.file_browser.load_data_files()
+
+    @trigger("data_load_variables")
     def data_load_variables(self):
         self.state.loading = True
         asynchronous.create_task(self._data_load_variables())

--- a/src/e3sm_quickview/components/dialogs.py
+++ b/src/e3sm_quickview/components/dialogs.py
@@ -11,6 +11,7 @@ class FileOpen(html.Div):
             with v3.VDialog(
                 model_value=(js.is_active("load-data"),),
                 **css.DIALOG_STYLES,
+                raw_attrs=["@keyup.enter=\"trigger('enter_load_files')\""],
             ):
                 file_browser.ui()
 
@@ -22,6 +23,9 @@ class StateDownload(html.Div):
             with v3.VDialog(
                 model_value=("show_export_dialog", False),
                 **css.DIALOG_STYLES,
+                raw_attrs=[
+                    "@keyup.enter=\"show_export_dialog=false;utils.download(download_name, trigger('download_state'), 'application/json')\""
+                ],
             ):
                 with v3.VCard(title="Download QuickView State file", rounded="lg"):
                     v3.VDivider()

--- a/src/e3sm_quickview/components/drawers.py
+++ b/src/e3sm_quickview/components/drawers.py
@@ -93,6 +93,9 @@ class FieldSelection(v3.VNavigationDrawer):
             with html.Div(
                 style="position:fixed;top:0;width: 500px;height:100vh;",
                 classes="d-flex flex-column",
+                raw_attrs=[
+                    "@keyup.enter=\"variables_selected.length > 0 && !variables_loaded && !loading ? trigger('data_load_variables') : null\""
+                ],
             ):
                 with v3.VCardActions(classes="pb-0", style="min-height: 0;"):
                     v3.VBtn(


### PR DESCRIPTION
New approach:
Uses local Vue @keyup.enter handlers on each dialog/panel to trigger the primary action on Enter/Return. Works regardless of which element has focus (text fields, checkboxes, table rows).

Panels handled:
- File loading dialog → loads files or imports state file
- State export dialog → saves/downloads state file
- Variable selection drawer → loads selected variables

Each handler respects the same disabled conditions as its corresponding button.

closes #79