### PR TITLE
fix: set default discrete colors per magnitude to 4

### DIFF
--- a/src/e3sm_quickview/view_manager.py
+++ b/src/e3sm_quickview/view_manager.py
@@ -61,7 +61,7 @@ class ViewConfiguration(dataclass.StateDataModel):
     color_blind: bool = dataclass.Sync(bool, False)
     use_log_scale: str = dataclass.Sync(str, "linear")
     discrete_log: bool = dataclass.Sync(bool, False)
-    n_discrete_colors: int = dataclass.Sync(int, 1)
+    n_discrete_colors: int = dataclass.Sync(int, 4)
     color_value_min: str = dataclass.Sync(str, "0")
     color_value_max: str = dataclass.Sync(str, "1")
     color_value_min_valid: bool = dataclass.Sync(bool, True)
@@ -196,7 +196,7 @@ class VariableView(TrameComponent):
         invert,
         log_scale,
         discrete_log=False,
-        n_discrete_colors=1,
+        n_discrete_colors=4,
         n_colors=255,
     ):
         self.config.preset = name

--- a/src/e3sm_quickview/view_manager2.py
+++ b/src/e3sm_quickview/view_manager2.py
@@ -77,7 +77,7 @@ class ViewConfiguration(dataclass.StateDataModel):
     color_blind: bool = dataclass.Sync(bool, False)
     use_log_scale: str = dataclass.Sync(str, "linear")
     discrete_log: bool = dataclass.Sync(bool, False)
-    n_discrete_colors: int = dataclass.Sync(int, 1)
+    n_discrete_colors: int = dataclass.Sync(int, 4)
     color_value_min: str = dataclass.Sync(str, "0")
     color_value_max: str = dataclass.Sync(str, "1")
     color_value_min_valid: bool = dataclass.Sync(bool, True)
@@ -193,7 +193,7 @@ class VariableView(TrameComponent):
         invert,
         log_scale,
         discrete_log=False,
-        n_discrete_colors=1,
+        n_discrete_colors=4,
         n_colors=255,
     ):
         self.config.preset = name


### PR DESCRIPTION
Set default discrete colors per magnitude to 4

- Changes the default n_discrete_colors from 1 to 4 for discrete colormap mode. 
- Applies to all scale types (linear, log, and symlog).
- Updated in both view_manager.py and view_manager2.py (dataclass default and method parameter).

closes #88 