### PR TITLE
fix(ui): improve field selection look and feel

### DIFF
--- a/src/e3sm_quickview/components/toolbars.py
+++ b/src/e3sm_quickview/components/toolbars.py
@@ -444,77 +444,74 @@ class DataSelection(html.Div):
                         ):
                             # --- Per-variable group ---
                             with v3.VSheet(
-                                classes="d-flex align-center rounded px-1 ga-1",
+                                classes=(
+                                    "`cursor-pointer d-flex align-center rounded px-2 ga-1 ${expanded_slice_track === track && 'border-primary border-md border-primary border-opacity-100'}`",
+                                ),
                                 color=(
                                     "expanded_slice_track === track ? 'grey-lighten-3' : 'grey-lighten-4'",
                                 ),
+                                style=(
+                                    "expanded_slice_track === track ? 'width: 100%; height: 32px;': 'height: 32px;'",
+                                ),
+                                v_tooltip_bottom="'Toggle ' + track + ' controls'",
                             ):
                                 # Toggle button with track name
-                                v3.VBtn(
+                                v3.VLabel(
                                     "{{ track }}",
-                                    v_tooltip_bottom="'Toggle ' + track + ' controls'",
-                                    flat=True,
-                                    variant=(
-                                        "expanded_slice_track === track ? 'flat' : 'outlined'",
-                                    ),
-                                    rounded=True,
+                                    classes="text-subtitle-1 font-weight-medium user-select-none",
                                     click="expanded_slice_track = expanded_slice_track === track ? null : track",
-                                    color=(
-                                        "expanded_slice_track === track ? 'primary' : ''",
-                                    ),
-                                    style=(
-                                        "'text-transform: none;' + (expanded_slice_track === track ? '' : ' background-color: white;')",
-                                    ),
                                 )
                                 # Expanded controls
-                                with html.Div(
-                                    v_if="expanded_slice_track === track",
-                                    classes="d-flex align-center ga-1",
-                                    style="height: 36px; overflow: visible;",
-                                ):
-                                    v3.VDivider(vertical=True, classes="mx-1")
-                                    # Text input
-                                    html.Input(
-                                        type="number",
-                                        value=("t_idx",),
-                                        min=[0],
-                                        max=["t_values ? t_values.length - 1 : 0"],
-                                        step=[1],
-                                        change=(
-                                            self.on_update_slider,
-                                            "[track, Number($event.target.value)]",
-                                        ),
-                                        style="width: 60px; height: 28px; padding: 16px 4px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; box-sizing: border-box; text-align: right;",
-                                    )
-                                    # Slider
-                                    v3.VSlider(
-                                        v_tooltip_bottom=(
-                                            "dim_units[track] ? parseFloat(t_values[t_idx]).toFixed(2) + ' ' + dim_units[track] : 'Index: ' + t_idx",
-                                        ),
-                                        model_value=("t_idx",),
-                                        update_modelValue=(
-                                            self.on_update_slider,
-                                            "[track, $event]",
-                                        ),
-                                        min=0,
-                                        max=("t_values.length - 1",),
-                                        step=1,
-                                        show_ticks="always",
-                                        hide_details=True,
-                                        density="compact",
-                                        style="min-width: 200px; max-width: 400px;",
-                                    )
-                                # Index label (shown when collapsed)
-                                v3.VLabel(
-                                    v_if="expanded_slice_track !== track",
-                                    v_text="`(${t_idx})`",
-                                    classes="font-weight-bold",
-                                )
+                                with v3.VExpandXTransition():
+                                    with html.Div(
+                                        classes="d-flex flex-fill align-center ga-2",
+                                        style="pointer",
+                                    ):
+                                        # Index label (shown when collapsed)
+                                        v3.VLabel(
+                                            v_if="expanded_slice_track !== track",
+                                            v_text="`(${t_idx + 1}/${t_values.length})`",
+                                            classes="text-caption user-select-none",
+                                            click="expanded_slice_track = expanded_slice_track === track ? null : track",
+                                        )
+                                        with v3.Template(v_else=True):
+                                            # Text input
+                                            html.Input(
+                                                type="number",
+                                                value=("t_idx",),
+                                                min=[0],
+                                                max=[
+                                                    "t_values ? t_values.length - 1 : 0"
+                                                ],
+                                                step=[1],
+                                                change=(
+                                                    self.on_update_slider,
+                                                    "[track, Number($event.target.value)]",
+                                                ),
+                                                classes="ml-2",
+                                                style="width: 60px; border: 1px solid #ccc; border-radius: 4px; text-align: right;",
+                                            )
+                                            # Slider
+                                            v3.VSlider(
+                                                model_value=("t_idx",),
+                                                update_modelValue=(
+                                                    self.on_update_slider,
+                                                    "[track, $event]",
+                                                ),
+                                                min=0,
+                                                max=("t_values.length - 1",),
+                                                step=1,
+                                                show_ticks="always",
+                                                hide_details=True,
+                                                density="compact",
+                                                style="min-width: 200px;",
+                                            )
                                 # Value + units label
                                 v3.VLabel(
                                     v_if="dim_units[track] && isNaN(Number(dim_units[track]))",
                                     v_text="`${parseFloat(t_values[t_idx]).toFixed(2)} ${dim_units[track]}`",
-                                    classes="font-italic text-medium-emphasis",
+                                    classes="text-subtitle-1 user-select-none",
+                                    click="expanded_slice_track = expanded_slice_track === track ? null : track",
                                 )
 
     def on_update_slider(self, dimension, index, *_, **__):

--- a/src/e3sm_quickview/module/serve/style.css
+++ b/src/e3sm_quickview/module/serve/style.css
@@ -14,3 +14,7 @@
   background: #f1f1f1;
   border-radius: 5px;
 }
+
+.user-select-none {
+  user-select: none;
+}


### PR DESCRIPTION
I tried to keep the same blue border when active and keep things more compact while using the full width for the slider when active.

<img width="1535" height="1161" alt="Screenshot 2026-05-11 at 17 09 24" src="https://github.com/user-attachments/assets/f279adec-091a-4676-bd16-bab5c9aada5b" />
<img width="1535" height="1161" alt="Screenshot 2026-05-11 at 17 09 33" src="https://github.com/user-attachments/assets/835ca4c8-3772-4fed-aa63-c3b9bcfe332d" />
<img width="1535" height="1161" alt="Screenshot 2026-05-11 at 17 11 45" src="https://github.com/user-attachments/assets/96d6fc08-2616-4f8a-aa90-ba01ee049938" />
<img width="1535" height="1161" alt="Screenshot 2026-05-11 at 17 11 59" src="https://github.com/user-attachments/assets/b8f73a98-3d79-4122-bb1b-e7ed05a71b2a" />
