### PR TITLE
fix: NaN transparency, preset click, and tick rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "trame-components",
     "trame-tauri>=0.6.2",
     "Pillow",
-    "trame-colormaps>=1.1.0",
+    "trame-colormaps>=1.4.2",
 ]
 
 [project.optional-dependencies]

--- a/src/e3sm_quickview/view_panel.py
+++ b/src/e3sm_quickview/view_panel.py
@@ -52,6 +52,7 @@ class VariableView(TrameComponent):
         input = source.data_reader.vtk_geometry
         self.mapper = vtkPolyDataMapper(input_connection=input.output_port)
         self.actor = vtkActor(mapper=self.mapper)
+        self.actor.ForceOpaqueOn()
         self.renderer.AddActor(self.actor)
 
         # Add annotation to the view (continents, gridlines)


### PR DESCRIPTION
- Add `ForceOpaqueOn()` to data actor so NaN cells render transparent via the LUT alpha channel without depth peeling overhead
- Bump trame-colormaps to `>=1.4.2` which includes fixes for preset click handling and tick label rendering